### PR TITLE
Include SDL2 dependencies and clean up window implementation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install dependencies
-        run: sudo apt-get update && sudo apt-get install -y cmake clang-format
+        run: sudo apt-get update && sudo apt-get install -y cmake clang-format pkg-config libsdl2-dev libgl1-mesa-dev
       - name: Configure
         run: cmake -S . -B build
       - name: Build

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,6 +3,14 @@
 This project aims to reimplement Winamp's Advanced Visualization Studio (AVS) as a standalone,
 portable engine and tooling.
 
+## Prerequisites
+
+Ensure the following packages are installed:
+
+```bash
+sudo apt-get install pkg-config libsdl2-dev libgl1-mesa-dev
+```
+
 ## Build Instructions
 
 ```bash

--- a/libs/avs-platform/include/avs/window.hpp
+++ b/libs/avs-platform/include/avs/window.hpp
@@ -1,9 +1,7 @@
 #pragma once
 
 #include <cstdint>
-
 #include <memory>
-
 #include <utility>
 
 namespace avs {
@@ -20,8 +18,6 @@ class Window {
  private:
   struct Impl;
   std::unique_ptr<Impl> impl_;
-  Impl* impl_;
-
 };
 
 }  // namespace avs

--- a/libs/avs-platform/src/window_sdl_gl.cpp
+++ b/libs/avs-platform/src/window_sdl_gl.cpp
@@ -4,9 +4,7 @@
 #include <SDL2/SDL.h>
 #include <SDL2/SDL_opengl.h>
 
-
 #include <memory>
-
 #include <stdexcept>
 
 namespace avs {
@@ -62,7 +60,6 @@ struct Window::Impl {
   int tex_w = 0;
   int tex_h = 0;
 };
-
 
 Window::Window(int w, int h, const char* title) : impl_(std::make_unique<Impl>()) {
   if (SDL_Init(SDL_INIT_VIDEO) != 0) {
@@ -139,7 +136,6 @@ Window::~Window() {
   SDL_GL_DeleteContext(impl_->ctx);
   SDL_DestroyWindow(impl_->win);
   SDL_Quit();
-  delete impl_;
 }
 
 bool Window::poll() {


### PR DESCRIPTION
## Summary
- remove redundant `Impl*` in window class and rely on `unique_ptr`
- document SDL2 and OpenGL prerequisites for building
- install SDL2 development packages in CI workflow

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68c3d1d4b26c832c89317dead61bf428