### PR TITLE
feat: add engine and effects

### DIFF
--- a/apps/avs-player/main.cpp
+++ b/apps/avs-player/main.cpp
@@ -1,9 +1,12 @@
 #include <chrono>
 #include <cstdint>
 #include <cstdio>
+#include <memory>
 #include <vector>
 
 #include "avs/audio.hpp"
+#include "avs/effects.hpp"
+#include "avs/engine.hpp"
 #include "avs/window.hpp"
 
 int main() {
@@ -14,34 +17,32 @@ int main() {
     return 1;
   }
 
-  std::vector<std::uint8_t> fb;
+  avs::Engine engine(1920, 1080);
+  std::vector<std::unique_ptr<avs::Effect>> chain;
+  chain.push_back(std::make_unique<avs::BlurEffect>());
+  chain.push_back(std::make_unique<avs::ColorMapEffect>());
+  chain.push_back(std::make_unique<avs::ConvolutionEffect>());
+  engine.setChain(std::move(chain));
+
   auto last = std::chrono::steady_clock::now();
-  float t = 0.0f;
   float printAccum = 0.0f;
   while (window.poll()) {
     auto now = std::chrono::steady_clock::now();
     float dt = std::chrono::duration<float>(now - last).count();
     last = now;
-    t += dt;
+
+    auto s = audio.poll();
+    engine.setAudio(s);
     printAccum += dt;
     if (printAccum > 0.5f) {
       printAccum = 0.0f;
-      auto s = audio.poll();
       std::printf("rms %.3f bands %.3f %.3f %.3f\n", s.rms, s.bands[0], s.bands[1], s.bands[2]);
     }
 
     auto [w, h] = window.size();
-    fb.resize(static_cast<size_t>(w) * h * 4);
-    for (int y = 0; y < h; ++y) {
-      for (int x = 0; x < w; ++x) {
-        int idx = (y * w + x) * 4;
-        fb[idx + 0] = static_cast<std::uint8_t>(x + t * 100);
-        fb[idx + 1] = static_cast<std::uint8_t>(y + t * 100);
-        fb[idx + 2] = static_cast<std::uint8_t>((x + y) + t * 100);
-        fb[idx + 3] = 255;
-      }
-    }
-    window.blit(fb.data(), w, h);
+    engine.resize(w, h);
+    engine.step(dt);
+    window.blit(engine.frame().rgba.data(), w, h);
   }
   return 0;
 }

--- a/libs/avs-core/CMakeLists.txt
+++ b/libs/avs-core/CMakeLists.txt
@@ -1,5 +1,9 @@
 add_library(avs-core STATIC
   src/core.cpp
+  src/engine.cpp
+  src/effects/blur.cpp
+  src/effects/colormap.cpp
+  src/effects/convolution.cpp
 )
-target_include_directories(avs-core PUBLIC include)
+target_include_directories(avs-core PUBLIC include ../avs-platform/include)
 target_compile_options(avs-core PRIVATE -Wall -Wextra -Werror)

--- a/libs/avs-core/include/avs/effects.hpp
+++ b/libs/avs-core/include/avs/effects.hpp
@@ -1,0 +1,55 @@
+#pragma once
+
+#include <array>
+#include <cstdint>
+#include <vector>
+
+namespace avs {
+
+struct Framebuffer {
+  int w = 0;
+  int h = 0;
+  std::vector<std::uint8_t> rgba;
+};
+
+class Effect {
+ public:
+  virtual ~Effect() = default;
+  virtual void init(int w, int h) {
+    (void)w;
+    (void)h;
+  }
+  virtual void process(const Framebuffer& in, Framebuffer& out) = 0;
+};
+
+class BlurEffect : public Effect {
+ public:
+  explicit BlurEffect(int radius = 5);
+  void init(int w, int h) override;
+  void process(const Framebuffer& in, Framebuffer& out) override;
+
+ private:
+  int radius_;
+  std::vector<float> kernel_;
+  Framebuffer temp_;
+};
+
+class ColorMapEffect : public Effect {
+ public:
+  void init(int w, int h) override;
+  void process(const Framebuffer& in, Framebuffer& out) override;
+
+ private:
+  std::array<std::uint8_t, 256 * 3> lut_;
+};
+
+class ConvolutionEffect : public Effect {
+ public:
+  void init(int w, int h) override;
+  void process(const Framebuffer& in, Framebuffer& out) override;
+
+ private:
+  std::array<int, 9> kernel_;
+};
+
+}  // namespace avs

--- a/libs/avs-core/include/avs/engine.hpp
+++ b/libs/avs-core/include/avs/engine.hpp
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <array>
+#include <memory>
+#include <vector>
+
+#include "avs/audio.hpp"
+#include "avs/effects.hpp"
+
+namespace avs {
+
+class Engine {
+ public:
+  Engine(int w, int h);
+
+  void resize(int w, int h);
+  void setAudio(const AudioState& a);
+  void step(float dt);
+  const Framebuffer& frame() const;
+  void setChain(std::vector<std::unique_ptr<Effect>> chain);
+
+ private:
+  void alloc(int w, int h);
+
+  std::array<Framebuffer, 2> fb_{};
+  int w_ = 0;
+  int h_ = 0;
+  int cur_ = 0;
+  std::vector<std::unique_ptr<Effect>> chain_;
+  AudioState audio_{};
+  float time_ = 0.0f;
+};
+
+}  // namespace avs

--- a/libs/avs-core/src/effects/blur.cpp
+++ b/libs/avs-core/src/effects/blur.cpp
@@ -1,0 +1,83 @@
+#include <algorithm>
+#include <cmath>
+
+#include "avs/effects.hpp"
+
+namespace avs {
+
+BlurEffect::BlurEffect(int radius) : radius_(radius) {}
+
+void BlurEffect::init(int w, int h) {
+  temp_.w = w;
+  temp_.h = h;
+  temp_.rgba.resize(static_cast<size_t>(w) * h * 4);
+  int size = radius_ * 2 + 1;
+  kernel_.resize(static_cast<size_t>(size));
+  float sigma = radius_ / 2.0f;
+  float sum = 0.0f;
+  for (int i = 0; i < size; ++i) {
+    int x = i - radius_;
+    float v = std::exp(-(x * x) / (2.0f * sigma * sigma));
+    kernel_[static_cast<size_t>(i)] = v;
+    sum += v;
+  }
+  for (auto& k : kernel_) {
+    k /= sum;
+  }
+}
+
+void BlurEffect::process(const Framebuffer& in, Framebuffer& out) {
+  temp_.w = in.w;
+  temp_.h = in.h;
+  out.w = in.w;
+  out.h = in.h;
+  temp_.rgba.resize(in.rgba.size());
+  out.rgba.resize(in.rgba.size());
+  int w = in.w;
+  int h = in.h;
+  int size = radius_ * 2 + 1;
+
+  // horizontal pass
+  for (int y = 0; y < h; ++y) {
+    for (int x = 0; x < w; ++x) {
+      float r = 0, g = 0, b = 0, a = 0;
+      for (int k = 0; k < size; ++k) {
+        int ix = std::clamp(x + k - radius_, 0, w - 1);
+        size_t idx = (static_cast<size_t>(y) * w + ix) * 4;
+        float wgt = kernel_[static_cast<size_t>(k)];
+        r += wgt * in.rgba[idx + 0];
+        g += wgt * in.rgba[idx + 1];
+        b += wgt * in.rgba[idx + 2];
+        a += wgt * in.rgba[idx + 3];
+      }
+      size_t outIdx = (static_cast<size_t>(y) * w + x) * 4;
+      temp_.rgba[outIdx + 0] = static_cast<std::uint8_t>(r);
+      temp_.rgba[outIdx + 1] = static_cast<std::uint8_t>(g);
+      temp_.rgba[outIdx + 2] = static_cast<std::uint8_t>(b);
+      temp_.rgba[outIdx + 3] = static_cast<std::uint8_t>(a);
+    }
+  }
+
+  // vertical pass
+  for (int y = 0; y < h; ++y) {
+    for (int x = 0; x < w; ++x) {
+      float r = 0, g = 0, b = 0, a = 0;
+      for (int k = 0; k < size; ++k) {
+        int iy = std::clamp(y + k - radius_, 0, h - 1);
+        size_t idx = (static_cast<size_t>(iy) * w + x) * 4;
+        float wgt = kernel_[static_cast<size_t>(k)];
+        r += wgt * temp_.rgba[idx + 0];
+        g += wgt * temp_.rgba[idx + 1];
+        b += wgt * temp_.rgba[idx + 2];
+        a += wgt * temp_.rgba[idx + 3];
+      }
+      size_t outIdx = (static_cast<size_t>(y) * w + x) * 4;
+      out.rgba[outIdx + 0] = static_cast<std::uint8_t>(r);
+      out.rgba[outIdx + 1] = static_cast<std::uint8_t>(g);
+      out.rgba[outIdx + 2] = static_cast<std::uint8_t>(b);
+      out.rgba[outIdx + 3] = static_cast<std::uint8_t>(a);
+    }
+  }
+}
+
+}  // namespace avs

--- a/libs/avs-core/src/effects/colormap.cpp
+++ b/libs/avs-core/src/effects/colormap.cpp
@@ -1,0 +1,66 @@
+#include <array>
+#include <cmath>
+
+#include "avs/effects.hpp"
+
+namespace avs {
+
+static std::array<std::uint8_t, 3> hsvToRgb(float h) {
+  float s = 1.0f;
+  float v = 1.0f;
+  float c = v * s;
+  float x = c * (1 - std::fabs(std::fmod(h / 60.0f, 2.0f) - 1));
+  float m = v - c;
+  float r = 0, g = 0, b = 0;
+  if (h < 60) {
+    r = c;
+    g = x;
+  } else if (h < 120) {
+    r = x;
+    g = c;
+  } else if (h < 180) {
+    g = c;
+    b = x;
+  } else if (h < 240) {
+    g = x;
+    b = c;
+  } else if (h < 300) {
+    r = x;
+    b = c;
+  } else {
+    r = c;
+    b = x;
+  }
+  return {static_cast<std::uint8_t>((r + m) * 255), static_cast<std::uint8_t>((g + m) * 255),
+          static_cast<std::uint8_t>((b + m) * 255)};
+}
+
+void ColorMapEffect::init(int /*w*/, int /*h*/) {
+  for (int i = 0; i < 256; ++i) {
+    float t = static_cast<float>(i) / 255.0f;
+    auto rgb = hsvToRgb(t * 360.0f);
+    lut_[i * 3 + 0] = rgb[0];
+    lut_[i * 3 + 1] = rgb[1];
+    lut_[i * 3 + 2] = rgb[2];
+  }
+}
+
+void ColorMapEffect::process(const Framebuffer& in, Framebuffer& out) {
+  out.w = in.w;
+  out.h = in.h;
+  out.rgba.resize(in.rgba.size());
+  int w = in.w;
+  int h = in.h;
+  for (int y = 0; y < h; ++y) {
+    for (int x = 0; x < w; ++x) {
+      size_t idx = (static_cast<size_t>(y) * w + x) * 4;
+      std::uint8_t g = in.rgba[idx];
+      out.rgba[idx + 0] = lut_[g * 3 + 0];
+      out.rgba[idx + 1] = lut_[g * 3 + 1];
+      out.rgba[idx + 2] = lut_[g * 3 + 2];
+      out.rgba[idx + 3] = 255;
+    }
+  }
+}
+
+}  // namespace avs

--- a/libs/avs-core/src/effects/convolution.cpp
+++ b/libs/avs-core/src/effects/convolution.cpp
@@ -1,0 +1,39 @@
+#include <algorithm>
+
+#include "avs/effects.hpp"
+
+namespace avs {
+
+void ConvolutionEffect::init(int /*w*/, int /*h*/) { kernel_ = {0, -1, 0, -1, 5, -1, 0, -1, 0}; }
+
+void ConvolutionEffect::process(const Framebuffer& in, Framebuffer& out) {
+  out.w = in.w;
+  out.h = in.h;
+  out.rgba.resize(in.rgba.size());
+  int w = in.w;
+  int h = in.h;
+  for (int y = 0; y < h; ++y) {
+    for (int x = 0; x < w; ++x) {
+      float r = 0, g = 0, b = 0;
+      for (int ky = -1; ky <= 1; ++ky) {
+        for (int kx = -1; kx <= 1; ++kx) {
+          int ix = std::clamp(x + kx, 0, w - 1);
+          int iy = std::clamp(y + ky, 0, h - 1);
+          size_t idx = (static_cast<size_t>(iy) * w + ix) * 4;
+          int k = kernel_[static_cast<size_t>(ky + 1) * 3 + (kx + 1)];
+          r += k * in.rgba[idx + 0];
+          g += k * in.rgba[idx + 1];
+          b += k * in.rgba[idx + 2];
+        }
+      }
+      size_t outIdx = (static_cast<size_t>(y) * w + x) * 4;
+      auto clamp8 = [](float v) { return static_cast<std::uint8_t>(std::clamp(v, 0.0f, 255.0f)); };
+      out.rgba[outIdx + 0] = clamp8(r);
+      out.rgba[outIdx + 1] = clamp8(g);
+      out.rgba[outIdx + 2] = clamp8(b);
+      out.rgba[outIdx + 3] = in.rgba[outIdx + 3];
+    }
+  }
+}
+
+}  // namespace avs

--- a/libs/avs-core/src/engine.cpp
+++ b/libs/avs-core/src/engine.cpp
@@ -1,0 +1,62 @@
+#include "avs/engine.hpp"
+
+#include <algorithm>
+#include <cmath>
+
+#include "avs/audio.hpp"
+
+namespace avs {
+
+Engine::Engine(int w, int h) { alloc(w, h); }
+
+void Engine::alloc(int w, int h) {
+  w_ = w;
+  h_ = h;
+  for (auto& fb : fb_) {
+    fb.w = w;
+    fb.h = h;
+    fb.rgba.resize(static_cast<size_t>(w) * h * 4);
+  }
+}
+
+void Engine::resize(int w, int h) {
+  if (w == w_ && h == h_) return;
+  alloc(w, h);
+  for (auto& e : chain_) {
+    e->init(w_, h_);
+  }
+}
+
+void Engine::setAudio(const AudioState& a) { audio_ = a; }
+
+void Engine::setChain(std::vector<std::unique_ptr<Effect>> chain) {
+  chain_ = std::move(chain);
+  for (auto& e : chain_) {
+    e->init(w_, h_);
+  }
+}
+
+void Engine::step(float dt) {
+  time_ += dt;
+  auto& base = fb_[0];
+  for (int y = 0; y < h_; ++y) {
+    for (int x = 0; x < w_; ++x) {
+      size_t idx = (static_cast<size_t>(y) * w_ + x) * 4;
+      base.rgba[idx + 0] = static_cast<std::uint8_t>(x + time_ * 100);
+      base.rgba[idx + 1] = static_cast<std::uint8_t>(y + time_ * 100);
+      base.rgba[idx + 2] = static_cast<std::uint8_t>((x + y) + time_ * 100);
+      base.rgba[idx + 3] = 255;
+    }
+  }
+  int in = 0;
+  int out = 1;
+  for (auto& e : chain_) {
+    e->process(fb_[in], fb_[out]);
+    std::swap(in, out);
+  }
+  cur_ = in;
+}
+
+const Framebuffer& Engine::frame() const { return fb_[cur_]; }
+
+}  // namespace avs

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,1 +1,6 @@
-add_test(NAME placeholder COMMAND ${CMAKE_COMMAND} -E true)
+find_package(GTest REQUIRED)
+
+add_executable(avs_core_tests avs_core_tests.cpp)
+target_link_libraries(avs_core_tests PRIVATE avs-core GTest::gtest_main)
+target_compile_options(avs_core_tests PRIVATE -Wall -Wextra -Werror)
+add_test(NAME avs_core_tests COMMAND avs_core_tests)

--- a/tests/avs_core_tests.cpp
+++ b/tests/avs_core_tests.cpp
@@ -1,0 +1,58 @@
+#include <gtest/gtest.h>
+
+#include "avs/effects.hpp"
+
+using namespace avs;
+
+TEST(BlurEffect, SpreadsLight) {
+  Framebuffer in;
+  in.w = 3;
+  in.h = 1;
+  in.rgba.assign(3 * 4, 0);
+  in.rgba[4 + 0] = 255;
+  in.rgba[4 + 1] = 255;
+  in.rgba[4 + 2] = 255;
+  in.rgba[4 + 3] = 255;
+  Framebuffer out;
+  BlurEffect blur(1);
+  blur.init(in.w, in.h);
+  blur.process(in, out);
+  EXPECT_GT(out.rgba[0], 0);
+  EXPECT_LT(out.rgba[0], out.rgba[4]);
+}
+
+TEST(ConvolutionEffect, PreservesConstantColor) {
+  Framebuffer in;
+  in.w = 2;
+  in.h = 2;
+  in.rgba.assign(2 * 2 * 4, 0);
+  for (size_t i = 0; i < in.rgba.size(); i += 4) {
+    in.rgba[i + 0] = 100;
+    in.rgba[i + 1] = 100;
+    in.rgba[i + 2] = 100;
+    in.rgba[i + 3] = 255;
+  }
+  Framebuffer out;
+  ConvolutionEffect conv;
+  conv.init(in.w, in.h);
+  conv.process(in, out);
+  for (size_t i = 0; i < out.rgba.size(); i += 4) {
+    EXPECT_EQ(out.rgba[i + 0], 100);
+    EXPECT_EQ(out.rgba[i + 1], 100);
+    EXPECT_EQ(out.rgba[i + 2], 100);
+    EXPECT_EQ(out.rgba[i + 3], 255);
+  }
+}
+
+TEST(ColorMapEffect, ProducesColor) {
+  Framebuffer in;
+  in.w = 1;
+  in.h = 1;
+  in.rgba = {128, 128, 128, 255};
+  Framebuffer out;
+  ColorMapEffect cm;
+  cm.init(in.w, in.h);
+  cm.process(in, out);
+  EXPECT_NE(out.rgba[0], out.rgba[1]);
+  EXPECT_EQ(out.rgba[3], 255);
+}


### PR DESCRIPTION
## Summary
- add avs-core Engine with ping-pong framebuffers
- implement blur, color map, and convolution CPU effects
- integrate engine in player and add unit tests

## Testing
- `cmake .. -DCMAKE_BUILD_TYPE=Debug`
- `cmake --build . -j$(nproc)`
- `ctest`


------
https://chatgpt.com/codex/tasks/task_e_68c3dd5c4a88832c96ce08e9944c3555