### PR TITLE
feat: add legacy preset parser and hot reload

### DIFF
--- a/apps/avs-player/CMakeLists.txt
+++ b/apps/avs-player/CMakeLists.txt
@@ -1,5 +1,3 @@
-find_package(SDL2 REQUIRED)
-
 add_executable(avs-player main.cpp)
-target_link_libraries(avs-player PRIVATE avs-core avs-platform SDL2::SDL2main)
+target_link_libraries(avs-player PRIVATE avs-core avs-platform)
 target_compile_options(avs-player PRIVATE -Wall -Wextra -Werror)

--- a/apps/avs-player/main.cpp
+++ b/apps/avs-player/main.cpp
@@ -1,6 +1,7 @@
 #include <chrono>
 #include <cstdint>
 #include <cstdio>
+#include <filesystem>
 #include <memory>
 #include <string>
 #include <vector>
@@ -8,12 +9,19 @@
 #include "avs/audio.hpp"
 #include "avs/effects.hpp"
 #include "avs/engine.hpp"
+#include "avs/fs.hpp"
+#include "avs/preset.hpp"
 #include "avs/window.hpp"
 
 int main(int argc, char** argv) {
   bool demoScript = false;
+  std::filesystem::path presetDir;
   for (int i = 1; i < argc; ++i) {
-    if (std::string(argv[i]) == "--demo-script") demoScript = true;
+    if (std::string(argv[i]) == "--demo-script") {
+      demoScript = true;
+    } else if (std::string(argv[i]) == "--presets" && i + 1 < argc) {
+      presetDir = argv[++i];
+    }
   }
 
   avs::Window window(1920, 1080, "AVS Player");
@@ -25,19 +33,43 @@ int main(int argc, char** argv) {
 
   avs::Engine engine(1920, 1080);
   std::vector<std::unique_ptr<avs::Effect>> chain;
-  if (demoScript) {
+
+  std::filesystem::path currentPreset;
+  std::unique_ptr<avs::FileWatcher> watcher;
+  auto loadPreset = [&]() {
+    if (currentPreset.empty()) return;
+    auto parsed = avs::parsePreset(currentPreset);
+    if (!parsed.warnings.empty()) {
+      for (const auto& w : parsed.warnings) {
+        std::fprintf(stderr, "%s\n", w.c_str());
+      }
+    }
+    engine.setChain(std::move(parsed.chain));
+    watcher = std::make_unique<avs::FileWatcher>(currentPreset);
+  };
+
+  if (!presetDir.empty()) {
+    for (auto& e : std::filesystem::directory_iterator(presetDir)) {
+      if (e.is_regular_file() && e.path().extension() == ".avs") {
+        currentPreset = e.path();
+        break;
+      }
+    }
+    loadPreset();
+  } else if (demoScript) {
     std::string frameScript;
     std::string pixelScript =
         "red = clamp(sin(x*0.01 + time)*bass,0,1);"
         "green = clamp(sin(y*0.01 + time)*mid,0,1);"
         "blue = clamp(sin((x+y)*0.01 + time)*treb,0,1);";
     chain.push_back(std::make_unique<avs::ScriptedEffect>(frameScript, pixelScript));
+    engine.setChain(std::move(chain));
   } else {
     chain.push_back(std::make_unique<avs::BlurEffect>());
     chain.push_back(std::make_unique<avs::ColorMapEffect>());
     chain.push_back(std::make_unique<avs::ConvolutionEffect>());
+    engine.setChain(std::move(chain));
   }
-  engine.setChain(std::move(chain));
 
   auto last = std::chrono::steady_clock::now();
   float printAccum = 0.0f;
@@ -52,6 +84,12 @@ int main(int argc, char** argv) {
     if (printAccum > 0.5f) {
       printAccum = 0.0f;
       std::printf("rms %.3f bands %.3f %.3f %.3f\n", s.rms, s.bands[0], s.bands[1], s.bands[2]);
+    }
+
+    if (!currentPreset.empty()) {
+      if (window.keyPressed('r') || (watcher && watcher->poll())) {
+        loadPreset();
+      }
     }
 
     auto [w, h] = window.size();

--- a/docs/compat.md
+++ b/docs/compat.md
@@ -1,0 +1,13 @@
+# Compatibility Notes
+
+The legacy AVS preset parser currently supports a minimal subset of effects:
+
+- Blur
+- ColorMap
+- Convolution
+- Scripted effect (frame script only)
+
+Unsupported effects are replaced with a no-op placeholder and emit a warning
+on load. Unknown fields from the preset are preserved internally for future
+round-tripping.
+

--- a/libs/avs-core/CMakeLists.txt
+++ b/libs/avs-core/CMakeLists.txt
@@ -6,6 +6,7 @@ add_library(avs-core STATIC
   src/effects/colormap.cpp
   src/effects/convolution.cpp
   src/effects/scripted.cpp
+  src/preset.cpp
 )
 target_include_directories(avs-core PUBLIC include ../avs-platform/include)
 target_compile_options(avs-core PRIVATE -Wall -Wextra -Werror)

--- a/libs/avs-core/include/avs/preset.hpp
+++ b/libs/avs-core/include/avs/preset.hpp
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <filesystem>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "avs/effects.hpp"
+
+namespace avs {
+
+struct ParsedPreset {
+  std::vector<std::unique_ptr<Effect>> chain;
+  std::vector<std::string> warnings;
+  std::vector<std::string> unknown;
+};
+
+ParsedPreset parsePreset(const std::filesystem::path& file);
+
+}  // namespace avs

--- a/libs/avs-core/src/preset.cpp
+++ b/libs/avs-core/src/preset.cpp
@@ -1,0 +1,68 @@
+#include "avs/preset.hpp"
+
+#include <cctype>
+#include <fstream>
+#include <sstream>
+#include <string>
+
+namespace avs {
+
+namespace {
+std::string trim(const std::string& s) {
+  size_t b = 0;
+  while (b < s.size() && std::isspace(static_cast<unsigned char>(s[b]))) ++b;
+  size_t e = s.size();
+  while (e > b && std::isspace(static_cast<unsigned char>(s[e - 1]))) --e;
+  return s.substr(b, e - b);
+}
+
+class PassThroughEffect : public Effect {
+ public:
+  void process(const Framebuffer& in, Framebuffer& out) override { out = in; }
+};
+}  // namespace
+
+ParsedPreset parsePreset(const std::filesystem::path& file) {
+  ParsedPreset result;
+  std::ifstream f(file);
+  if (!f) {
+    result.warnings.push_back("failed to open preset");
+    return result;
+  }
+  std::string line;
+  while (std::getline(f, line)) {
+    std::string t = trim(line);
+    if (t.empty() || t[0] == '#') continue;
+    std::istringstream iss(t);
+    std::string type;
+    iss >> type;
+    if (type == "blur") {
+      int radius = 5;
+      std::string token;
+      while (iss >> token) {
+        if (token.rfind("radius=", 0) == 0) {
+          radius = std::stoi(token.substr(7));
+        } else {
+          result.unknown.push_back(token);
+        }
+      }
+      result.chain.push_back(std::make_unique<BlurEffect>(radius));
+    } else if (type == "colormap") {
+      result.chain.push_back(std::make_unique<ColorMapEffect>());
+    } else if (type == "convolution") {
+      result.chain.push_back(std::make_unique<ConvolutionEffect>());
+    } else if (type == "scripted") {
+      std::string script;
+      std::getline(iss, script);
+      script = trim(script);
+      result.chain.push_back(std::make_unique<ScriptedEffect>(script, ""));
+    } else {
+      result.warnings.push_back("unsupported effect: " + type);
+      result.chain.push_back(std::make_unique<PassThroughEffect>());
+      result.unknown.push_back(t);
+    }
+  }
+  return result;
+}
+
+}  // namespace avs

--- a/libs/avs-platform/CMakeLists.txt
+++ b/libs/avs-platform/CMakeLists.txt
@@ -21,6 +21,7 @@ add_library(avs-platform STATIC
   src/window_sdl_gl.cpp
   src/audio_portaudio.cpp
   src/fft_kiss.cpp
+  src/fs_posix.cpp
   ../third_party/kissfft/kiss_fft.c
   ../third_party/kissfft/kiss_fftr.c
 )

--- a/libs/avs-platform/include/avs/fs.hpp
+++ b/libs/avs-platform/include/avs/fs.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <filesystem>
+
+namespace avs {
+
+class FileWatcher {
+ public:
+  explicit FileWatcher(const std::filesystem::path& path);
+  ~FileWatcher();
+
+  // Returns true if the file changed since the last call.
+  bool poll();
+
+ private:
+  std::filesystem::path path_;
+  std::filesystem::file_time_type last_{};
+#ifdef __linux__
+  int fd_ = -1;
+  int wd_ = -1;
+#endif
+};
+
+}  // namespace avs

--- a/libs/avs-platform/include/avs/window.hpp
+++ b/libs/avs-platform/include/avs/window.hpp
@@ -14,6 +14,7 @@ class Window {
   bool poll();
   std::pair<int, int> size() const;
   void blit(const std::uint8_t* rgba, int width, int height);
+  bool keyPressed(int key);
 
  private:
   struct Impl;

--- a/libs/avs-platform/src/fs_posix.cpp
+++ b/libs/avs-platform/src/fs_posix.cpp
@@ -1,0 +1,50 @@
+#include <sys/inotify.h>
+#include <unistd.h>
+
+#include <filesystem>
+
+#include "avs/fs.hpp"
+
+namespace avs {
+
+FileWatcher::FileWatcher(const std::filesystem::path& path) : path_(path) {
+#ifdef __linux__
+  fd_ = inotify_init1(IN_NONBLOCK);
+  if (fd_ >= 0) {
+    wd_ = inotify_add_watch(fd_, path_.c_str(), IN_CLOSE_WRITE | IN_MOVED_TO | IN_MODIFY);
+    if (wd_ < 0) {
+      close(fd_);
+      fd_ = -1;
+    }
+  }
+#endif
+  if (fd_ < 0) {
+    if (std::filesystem::exists(path_)) last_ = std::filesystem::last_write_time(path_);
+  }
+}
+
+FileWatcher::~FileWatcher() {
+#ifdef __linux__
+  if (wd_ >= 0) inotify_rm_watch(fd_, wd_);
+  if (fd_ >= 0) close(fd_);
+#endif
+}
+
+bool FileWatcher::poll() {
+#ifdef __linux__
+  if (fd_ >= 0) {
+    char buf[sizeof(inotify_event) * 4];
+    int len = read(fd_, buf, sizeof(buf));
+    if (len > 0) return true;
+  }
+#endif
+  auto t = std::filesystem::exists(path_) ? std::filesystem::last_write_time(path_)
+                                          : std::filesystem::file_time_type::min();
+  if (t != last_) {
+    last_ = t;
+    return true;
+  }
+  return false;
+}
+
+}  // namespace avs

--- a/libs/avs-platform/src/window_sdl_gl.cpp
+++ b/libs/avs-platform/src/window_sdl_gl.cpp
@@ -6,6 +6,7 @@
 
 #include <memory>
 #include <stdexcept>
+#include <unordered_set>
 
 namespace avs {
 
@@ -59,6 +60,7 @@ struct Window::Impl {
   int h = 0;
   int tex_w = 0;
   int tex_h = 0;
+  std::unordered_set<int> keys;
 };
 
 Window::Window(int w, int h, const char* title) : impl_(std::make_unique<Impl>()) {
@@ -139,6 +141,7 @@ Window::~Window() {
 }
 
 bool Window::poll() {
+  impl_->keys.clear();
   SDL_Event e;
   while (SDL_PollEvent(&e)) {
     if (e.type == SDL_QUIT) return false;
@@ -147,6 +150,9 @@ bool Window::poll() {
       impl_->w = e.window.data1;
       impl_->h = e.window.data2;
       glViewport(0, 0, impl_->w, impl_->h);
+    }
+    if (e.type == SDL_KEYDOWN) {
+      impl_->keys.insert(e.key.keysym.sym);
     }
   }
   return true;
@@ -167,6 +173,15 @@ void Window::blit(const std::uint8_t* rgba, int width, int height) {
   glBindVertexArray(impl_->vao);
   glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
   SDL_GL_SwapWindow(impl_->win);
+}
+
+bool Window::keyPressed(int key) {
+  auto it = impl_->keys.find(key);
+  if (it != impl_->keys.end()) {
+    impl_->keys.erase(it);
+    return true;
+  }
+  return false;
 }
 
 }  // namespace avs

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,6 +1,6 @@
 find_package(GTest REQUIRED)
 
 add_executable(avs_core_tests avs_core_tests.cpp)
-target_link_libraries(avs_core_tests PRIVATE avs-core GTest::gtest_main)
+target_link_libraries(avs_core_tests PRIVATE avs-core avs-platform GTest::gtest_main)
 target_compile_options(avs_core_tests PRIVATE -Wall -Wextra -Werror)
 add_test(NAME avs_core_tests COMMAND avs_core_tests)


### PR DESCRIPTION
## Summary
- add file watcher utility with inotify and timestamp fallback
- support parsing simple legacy presets with no-op substitution
- wire avs-player for preset hot reload and document unsupported effects

## Testing
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug`
- `cmake --build build -j$(nproc)`
- `cd build && ctest`

------
https://chatgpt.com/codex/tasks/task_e_68c3f1028c6c832c9eccb657d004de6e