### PR TITLE
fix: surface portaudio input underflow

### DIFF
--- a/libs/avs-platform/include/avs/audio_portaudio_internal.hpp
+++ b/libs/avs-platform/include/avs/audio_portaudio_internal.hpp
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <cstddef>
+#include <vector>
+
+namespace avs::portaudio_detail {
+
+struct CallbackResult {
+  size_t nextWriteIndex;
+  bool underflow;
+};
+
+CallbackResult processCallbackInput(const float* input, size_t samples, size_t writeIndex,
+                                    size_t mask, std::vector<float>& ring);
+
+}  // namespace avs::portaudio_detail


### PR DESCRIPTION
## Summary
- detect PortAudio input underflow conditions in the callback and stop capture when they persist
- expose a small helper for processing callback data so underflow state can be unit tested
- add a unit test that exercises the helper with a null input buffer to confirm the underflow signal

## Testing
- cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug
- cmake --build build -j$(nproc)
- ctest


------
https://chatgpt.com/codex/tasks/task_e_68cab60f12dc832c9d524f2a618bcc59