### PR TITLE
Fix --wav handling in interactive mode

### DIFF
--- a/apps/avs-player/main.cpp
+++ b/apps/avs-player/main.cpp
@@ -215,6 +215,11 @@ int main(int argc, char** argv) {
     }
   }
 
+  if (!headless && !wavPath.empty()) {
+    std::fprintf(stderr, "--wav requires --headless\n");
+    return 1;
+  }
+
   if (headless) {
     if (wavPath.empty() || presetPath.empty() || frames <= 0) {
       std::fprintf(stderr, "--headless requires --wav, --preset and --frames\n");

--- a/docs/README.md
+++ b/docs/README.md
@@ -31,4 +31,12 @@ Run the stub player after building:
 ./apps/avs-player/avs-player
 ```
 
+To drive rendering from a WAV file, run the player in headless mode. Supplying
+`--wav` without `--headless` will terminate with an error.
+
+```bash
+./apps/avs-player/avs-player --headless --wav tests/data/test.wav \
+  --preset tests/data/simple.avs --frames 120 --out output_dir
+```
+
 More documentation will be added as the project evolves.

--- a/tests/deterministic_render_test.cpp
+++ b/tests/deterministic_render_test.cpp
@@ -31,3 +31,17 @@ TEST(DeterministicRender, MatchesGolden) {
   EXPECT_FALSE(std::getline(got, gLine));
   EXPECT_FALSE(std::getline(expected, eLine));
 }
+
+TEST(DeterministicRender, WavRequiresHeadless) {
+  namespace fs = std::filesystem;
+  fs::path buildDir{BUILD_DIR};
+  fs::path sourceDir{SOURCE_DIR};
+  fs::path player = buildDir / "apps/avs-player/avs-player";
+  fs::path wav = sourceDir / "tests/data/test.wav";
+  fs::path preset = sourceDir / "tests/data/simple.avs";
+
+  std::string cmd = player.string() + " --wav " + wav.string() + " --preset " +
+                    preset.string() + " --frames 60";
+  int ret = std::system(cmd.c_str());
+  EXPECT_NE(ret, 0);
+}


### PR DESCRIPTION
## Summary
- fail fast when `--wav` is provided without `--headless` to avoid falling back to live capture
- document the headless requirement for WAV-driven runs in the CLI docs
- extend the deterministic render integration test to cover the new failure mode

## Testing
- `cmake -S . -B build`
- `cmake --build build -j4`
- `cd build && ctest`


------
https://chatgpt.com/codex/tasks/task_e_68cab7d944e4832ca82c6a69fcec5ea6