### PR TITLE
feat: add CLI controls for selecting audio capture devices

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -36,6 +36,22 @@ Use `--sample-rate` and `--channels` to ask the device for a particular format;
 the player will fall back to the device defaults if the request is not
 available and resample to the engine's 48 kHz internal representation.
 
+Enumerate capture devices (and their numeric identifiers) via:
+
+```bash
+./apps/avs-player/avs-player --list-input-devices
+```
+
+Pick a device either by index or by matching part of its name:
+
+```bash
+./apps/avs-player/avs-player --input-device 2
+./apps/avs-player/avs-player --input-device "USB"
+```
+
+If the chosen endpoint cannot capture audio, the player reports a descriptive
+error instead of silently falling back to the default input.
+
 To drive rendering from a WAV file, run the player in headless mode. Supplying
 `--wav` without `--headless` will terminate with an error.
 

--- a/libs/avs-platform/include/avs/audio.hpp
+++ b/libs/avs-platform/include/avs/audio.hpp
@@ -2,6 +2,7 @@
 
 #include <array>
 #include <optional>
+#include <string>
 #include <vector>
 
 namespace avs {
@@ -21,6 +22,7 @@ struct AudioInputConfig {
   int engineChannels = 2;
   std::optional<int> requestedSampleRate;
   std::optional<int> requestedChannels;
+  std::optional<std::string> requestedDevice;
 };
 
 class AudioInput {


### PR DESCRIPTION
## Summary
- allow AudioInputConfig to carry an optional PortAudio device identifier and validate the requested endpoint before opening a stream
- add `--list-input-devices` and `--input-device` flags to avs-player and document the workflow in the README
- cover the negotiation helper with a regression test that exercises channel clamping when a device offers fewer inputs

## Testing
- cmake --build . -j$(nproc)
- ctest

------
https://chatgpt.com/codex/tasks/task_e_68cb7ba1e41c832c8b5785be1c3e5531