### PR TITLE
feat: allow selecting PortAudio devices by identifier

### DIFF
--- a/apps/avs-player/main.cpp
+++ b/apps/avs-player/main.cpp
@@ -179,7 +179,8 @@ class OfflineAudio {
     const size_t legacySamples = avs::AudioState::kLegacyVisSamples;
     const size_t channelCount = static_cast<size_t>(wav_.channels);
     if (legacySamples > 0 && channelCount > 0) {
-      const size_t sampleStart = kFftSize > legacySamples ? static_cast<size_t>(kFftSize) - legacySamples : 0;
+      const size_t sampleStart =
+          kFftSize > legacySamples ? static_cast<size_t>(kFftSize) - legacySamples : 0;
       for (unsigned int ch = 0; ch < std::min<unsigned int>(wav_.channels, 2); ++ch) {
         auto& dest = state.oscilloscope[static_cast<size_t>(ch)];
         for (size_t i = 0; i < legacySamples; ++i) {
@@ -384,7 +385,7 @@ int main(int argc, char** argv) {
     audioConfig.requestedChannels = requestedChannels;
   }
   if (requestedInputDevice) {
-    audioConfig.requestedDevice = requestedInputDevice;
+    audioConfig.requestedDeviceIdentifier = requestedInputDevice;
   }
   avs::AudioInput audio(audioConfig);
   if (!audio.ok()) {

--- a/docs/README.md
+++ b/docs/README.md
@@ -34,7 +34,9 @@ Run the stub player after building:
 The runtime can request specific capture parameters when talking to PortAudio.
 Use `--sample-rate` and `--channels` to ask the device for a particular format;
 the player will fall back to the device defaults if the request is not
-available and resample to the engine's 48 kHz internal representation.
+available and resample to the engine's 48 kHz internal representation. Library
+consumers can achieve the same behaviour by setting
+`AudioInputConfig::requestedSampleRate` and `AudioInputConfig::requestedChannels`.
 
 Enumerate capture devices (and their numeric identifiers) via:
 
@@ -51,6 +53,11 @@ Pick a device either by index or by matching part of its name:
 
 If the chosen endpoint cannot capture audio, the player reports a descriptive
 error instead of silently falling back to the default input.
+
+Embedding applications can mirror this behaviour through
+`AudioInputConfig::requestedDeviceIdentifier`. Set the optional string to a
+PortAudio device index or to a substring of the desired device name before
+constructing `avs::AudioInput`.
 
 To drive rendering from a WAV file, run the player in headless mode. Supplying
 `--wav` without `--headless` will terminate with an error.

--- a/libs/avs-platform/include/avs/audio.hpp
+++ b/libs/avs-platform/include/avs/audio.hpp
@@ -11,15 +11,15 @@ struct AudioState {
   static constexpr size_t kLegacyVisSamples = 576;
   using LegacyBuffer = std::array<float, kLegacyVisSamples>;
 
-  float rms = 0.0f;                             // 0..1
-  std::array<float, 3> bands{{0.f, 0.f, 0.f}};  // bass, mid, treble smoothed
-  std::vector<float> spectrum;                  // N/2 magnitudes [0,1]
-  std::array<LegacyBuffer, 2> spectrumLegacy{}; // legacy 576-bin FFT view per channel
-  std::array<LegacyBuffer, 2> oscilloscope{};   // legacy 576-sample oscilloscope per channel
-  double timeSeconds = 0.0;                     // audio clock
-  int sampleRate = 0;                           // rate of data stored in spectrum
-  int inputSampleRate = 0;                      // physical capture device rate
-  int channels = 0;                             // channel count used for analysis
+  float rms = 0.0f;                              // 0..1
+  std::array<float, 3> bands{{0.f, 0.f, 0.f}};   // bass, mid, treble smoothed
+  std::vector<float> spectrum;                   // N/2 magnitudes [0,1]
+  std::array<LegacyBuffer, 2> spectrumLegacy{};  // legacy 576-bin FFT view per channel
+  std::array<LegacyBuffer, 2> oscilloscope{};    // legacy 576-sample oscilloscope per channel
+  double timeSeconds = 0.0;                      // audio clock
+  int sampleRate = 0;                            // rate of data stored in spectrum
+  int inputSampleRate = 0;                       // physical capture device rate
+  int channels = 0;                              // channel count used for analysis
 };
 
 struct AudioInputConfig {
@@ -27,7 +27,7 @@ struct AudioInputConfig {
   int engineChannels = 2;
   std::optional<int> requestedSampleRate;
   std::optional<int> requestedChannels;
-  std::optional<std::string> requestedDevice;
+  std::optional<std::string> requestedDeviceIdentifier;
 };
 
 class AudioInput {

--- a/libs/avs-platform/include/avs/audio_portaudio_internal.hpp
+++ b/libs/avs-platform/include/avs/audio_portaudio_internal.hpp
@@ -3,6 +3,7 @@
 #include <cstddef>
 #include <functional>
 #include <optional>
+#include <string>
 #include <vector>
 
 namespace avs::portaudio_detail {
@@ -39,5 +40,20 @@ using FormatSupportQuery = std::function<bool(int, double)>;
 StreamNegotiationResult negotiateStream(const StreamNegotiationRequest& request,
                                         const StreamNegotiationDeviceInfo& device,
                                         const FormatSupportQuery& isSupported);
+
+struct DeviceSummary {
+  int index = -1;
+  std::string name;
+  int maxInputChannels = 0;
+};
+
+struct DeviceSelectionResult {
+  std::optional<int> index;
+  std::string error;
+};
+
+DeviceSelectionResult resolveInputDeviceIdentifier(const std::optional<std::string>& identifier,
+                                                   int deviceCount,
+                                                   const std::vector<DeviceSummary>& devices);
 
 }  // namespace avs::portaudio_detail


### PR DESCRIPTION
## Summary
- add `requestedDeviceIdentifier` to `AudioInputConfig` and expose device matching helpers for PortAudio
- extend the PortAudio backend and player CLI to resolve named or indexed capture devices with detailed errors
- document the workflow and cover device selection with new unit tests

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build`


------
https://chatgpt.com/codex/tasks/task_e_68d1f52f58f4832cbde7a311c4b6704b