### PR TITLE
feat: allow interactive wav playback

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -52,8 +52,11 @@ Pick a device either by index or by matching part of its name:
 If the chosen endpoint cannot capture audio, the player reports a descriptive
 error instead of silently falling back to the default input.
 
-To drive rendering from a WAV file, run the player in headless mode. Supplying
-`--wav` without `--headless` will terminate with an error.
+To drive rendering from a WAV file, you can either run the player in headless
+mode for deterministic output, or preview interactively by omitting
+`--headless`. When running interactively from a WAV source, `--frames <n>` can
+be supplied to automatically exit after `n` frames (handy for tests or scripted
+captures).
 
 ```bash
 ./apps/avs-player/avs-player --headless --wav tests/data/test.wav \

--- a/tests/deterministic_render_test.cpp
+++ b/tests/deterministic_render_test.cpp
@@ -85,7 +85,7 @@ TEST(DeterministicRender, MatchesGolden) {
   EXPECT_FALSE(std::getline(expected, eLine));
 }
 
-TEST(DeterministicRender, WavRequiresHeadless) {
+TEST(DeterministicRender, InteractiveWavPlaybackUsesOfflineAudio) {
   namespace fs = std::filesystem;
   fs::path buildDir{BUILD_DIR};
   fs::path sourceDir{SOURCE_DIR};
@@ -93,10 +93,17 @@ TEST(DeterministicRender, WavRequiresHeadless) {
   fs::path wav = sourceDir / "tests/data/test.wav";
   fs::path preset = sourceDir / "tests/data/simple.avs";
 
+#if defined(_WIN32)
+  _putenv("SDL_AUDIODRIVER=dummy");
+#else
+  setenv("SDL_VIDEODRIVER", "offscreen", 1);
+  setenv("SDL_AUDIODRIVER", "dummy", 1);
+#endif
+
   std::string cmd =
-      player.string() + " --wav " + wav.string() + " --preset " + preset.string() + " --frames 60";
+      player.string() + " --wav " + wav.string() + " --preset " + preset.string() + " --frames 10";
   int ret = std::system(cmd.c_str());
-  EXPECT_NE(ret, 0);
+  EXPECT_EQ(ret, 0);
 }
 
 TEST(DeterministicRender, HandlesGeneratedSampleRates) {


### PR DESCRIPTION
## Summary
- enable avs-player to reuse OfflineAudio when `--wav` is supplied in interactive mode, allowing scripted runs to limit execution via `--frames`
- refresh the CLI usage text and docs to describe interactive WAV playback options
- extend the deterministic render integration test to exercise interactive WAV playback through the new path

## Testing
- `cmake --build build`
- `ctest`


------
https://chatgpt.com/codex/tasks/task_e_68d1f5574e58832c9a3fdf3123198d8d