### PR TITLE
Fix NS-EEL lexer prototypes

### DIFF
--- a/codex/jobs/01-warn-nseel-prototypes.yaml
+++ b/codex/jobs/01-warn-nseel-prototypes.yaml
@@ -1,6 +1,6 @@
 id: warn-nseel-prototypes
 title: Export NS-EEL parser prototypes
-status: READY
+status: IN-REVIEW
 labels: [warnings, ns-eel, build]
 depends_on: []
 goal: >

--- a/libs/third_party/ns-eel/ns-eel-int.h
+++ b/libs/third_party/ns-eel/ns-eel-int.h
@@ -102,12 +102,7 @@ typedef struct _compileContext compileContext;
 
 #define YYSTYPE opcodeRec *
 
-#ifdef NSEEL_SUPER_MINIMAL_LEXER
-int nseellex(opcodeRec **output, YYLTYPE *yylloc_param, compileContext *scctx);
-#else
-int nseellex(YYSTYPE *yylval_param, YYLTYPE *yylloc_param, void *yyscanner);
-#endif
-void nseelerror(YYLTYPE *pos, compileContext *ctx, const char *str);
+#include "nseel_lexer_decls.h"
 
 #define NSEEL_CLOSEFACTOR 0.00001
 

--- a/libs/third_party/ns-eel/nseel_lexer_decls.h
+++ b/libs/third_party/ns-eel/nseel_lexer_decls.h
@@ -1,0 +1,56 @@
+/*
+  Nullsoft Expression Evaluator Library (NS-EEL)
+
+  nseel_lexer_decls.h: shared lexer/error function declarations.
+
+  This software is provided 'as-is', without any express or implied
+  warranty.  In no event will the authors be held liable for any damages
+  arising from the use of this software.
+
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely, subject to the following restrictions:
+
+  1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+  2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+  3. This notice may not be removed or altered from any source distribution.
+*/
+
+#ifndef NSEEL_LEXER_DECLS_H_
+#define NSEEL_LEXER_DECLS_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifndef NSEEL_LEXER_DECL_FWD_DECLS
+#define NSEEL_LEXER_DECL_FWD_DECLS
+struct opcodeRec;
+struct YYLTYPE;
+struct _compileContext;
+#endif
+
+#ifdef NSEEL_SUPER_MINIMAL_LEXER
+int nseellex(struct opcodeRec **output,
+             struct YYLTYPE *yylloc_param,
+             struct _compileContext *scctx);
+#else
+int nseellex(YYSTYPE *yylval_param,
+             struct YYLTYPE *yylloc_param,
+             void *yyscanner);
+#endif
+
+void nseelerror(struct YYLTYPE *pos,
+                struct _compileContext *ctx,
+                const char *str);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+
+#endif  // NSEEL_LEXER_DECLS_H_
+

--- a/libs/third_party/ns-eel/y.tab.c
+++ b/libs/third_party/ns-eel/y.tab.c
@@ -140,6 +140,7 @@
 
 #include "y.tab.h"
 #include "ns-eel-int.h"
+#include "nseel_lexer_decls.h"
   
 #define scanner context->scanner
 #define YY_(x) ("")


### PR DESCRIPTION
### Summary
Closes: #[issue-number] • Job: [Codex:warn-nseel-prototypes]

### Checklist
- [x] Steps completed (fix: export ns-eel lexer prototypes)
- [x] Acceptance criteria satisfied
- [ ] Tests added/updated and passing (`ctest`) (fails: deterministic_render_test missing golden hashes in repo)
- [ ] Warnings treated as errors (`-Werror`) clean (vendored PortAudio still emits JACK/ALSA deprecation/truncation warnings)
- [x] No binary blobs committed
- [x] If binaries required for review, ZIP artifact attached (name: `binary-assets-<branch>.zip`)

### Notes
- Device/sample-rate notes (if audio): n/a
- Preset/parser fixtures updated: none


------
https://chatgpt.com/codex/tasks/task_e_68d238419cec832c99327f51445b000a