### PR TITLE
feat: expose device default audio negotiation controls

### DIFF
--- a/codex/jobs/08-audio-resampling-negotiation.yaml
+++ b/codex/jobs/08-audio-resampling-negotiation.yaml
@@ -1,6 +1,6 @@
 id: audio-resampling-negotiation
 title: Negotiate or resample live audio capture
-status: READY
+status: IN-REVIEW
 labels: [audio, portaudio, resampling, cli]
 depends_on: []
 goal: >

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,15 +28,17 @@ ctest
 Run the stub player after building:
 
 ```bash
-./apps/avs-player/avs-player [--sample-rate 48000] [--channels 2]
+./apps/avs-player/avs-player [--sample-rate 48000|default] [--channels 2|default]
 ```
 
 The runtime can request specific capture parameters when talking to PortAudio.
 Use `--sample-rate` and `--channels` to ask the device for a particular format;
-the player will fall back to the device defaults if the request is not
-available and resample to the engine's 48 kHz internal representation. Library
-consumers can achieve the same behaviour by setting
-`AudioInputConfig::requestedSampleRate` and `AudioInputConfig::requestedChannels`.
+pass `default` to either flag to explicitly request the device defaults. The
+player falls back to the hardware defaults when the request is not available
+and resamples to the engine's 48 kHz internal representation. Library consumers
+can achieve the same behaviour by adjusting `AudioInputConfig::requestedSampleRate`,
+`AudioInputConfig::requestedChannels`, and the new `useDeviceDefaultSampleRate`
+and `useDeviceDefaultChannels` toggles.
 
 Enumerate capture devices (and their numeric identifiers) via:
 

--- a/libs/avs-platform/include/avs/audio.hpp
+++ b/libs/avs-platform/include/avs/audio.hpp
@@ -25,6 +25,8 @@ struct AudioState {
 struct AudioInputConfig {
   int engineSampleRate = 48000;
   int engineChannels = 2;
+  bool useDeviceDefaultSampleRate = true;
+  bool useDeviceDefaultChannels = false;
   std::optional<int> requestedSampleRate;
   std::optional<int> requestedChannels;
   std::optional<std::string> requestedDeviceIdentifier;

--- a/libs/avs-platform/include/avs/audio_portaudio_internal.hpp
+++ b/libs/avs-platform/include/avs/audio_portaudio_internal.hpp
@@ -21,15 +21,18 @@ CallbackResult processCallbackInput(const float* input, size_t samples, size_t w
 bool callbackIndicatesUnderflow(const void* input, PaStreamCallbackFlags statusFlags);
 
 struct StreamNegotiationRequest {
-  int engineSampleRate;
-  int engineChannels;
+  int engineSampleRate = 0;
+  int engineChannels = 0;
   std::optional<int> requestedSampleRate;
   std::optional<int> requestedChannels;
+  bool useDeviceDefaultSampleRate = true;
+  bool useDeviceDefaultChannels = false;
 };
 
 struct StreamNegotiationDeviceInfo {
-  double defaultSampleRate;
-  int maxInputChannels;
+  double defaultSampleRate = 0.0;
+  int maxInputChannels = 0;
+  int defaultInputChannels = 0;
 };
 
 struct StreamNegotiationResult {


### PR DESCRIPTION
### Summary
Closes: #[issue-number] • Job: [Codex:audio-resampling-negotiation]

### Checklist
- [x] Steps completed (map each step to a commit or note)
- [x] Acceptance criteria satisfied
- [ ] Tests added/updated and passing (`ctest`)
- [ ] Warnings treated as errors (`-Werror`) clean
- [x] No binary blobs committed
- [ ] If binaries required for review, ZIP artifact attached (name: `binary-assets-<branch>.zip`)

### Notes
- Device/sample-rate notes (if audio): Added CLI `default` tokens and device-default toggles in `AudioInputConfig`; new tests cover 44.1 kHz, 48 kHz, and device-default channel flows. Build currently blocked in this container because the SDL2 development package (`sdl2>=2.28`) is unavailable, so `ctest` could not be executed.
- Preset/parser fixtures updated: N/A


------
https://chatgpt.com/codex/tasks/task_e_68d25e67c5bc832cbdf0356e551f1dcb