### PR TITLE
Add tests for PortAudio input underflow handling

### DIFF
--- a/codex/jobs/09-engine-pa-underflow-surfacing.yaml
+++ b/codex/jobs/09-engine-pa-underflow-surfacing.yaml
@@ -1,6 +1,6 @@
 id: engine-pa-underflow-surfacing
 title: Detect and surface PortAudio input underflow
-status: READY
+status: IN-REVIEW
 labels: [audio, portaudio, reliability]
 depends_on: []
 goal: >

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -15,6 +15,11 @@ target_compile_options(avs_core_tests PRIVATE -Wall -Wextra -Werror)
 target_compile_definitions(avs_core_tests PRIVATE BUILD_DIR="${CMAKE_BINARY_DIR}" SOURCE_DIR="${CMAKE_SOURCE_DIR}")
 add_test(NAME avs_core_tests COMMAND avs_core_tests)
 
+add_executable(audio_underflow_tests audio_underflow_tests.cpp)
+target_link_libraries(audio_underflow_tests PRIVATE avs-platform GTest::gtest_main)
+target_compile_options(audio_underflow_tests PRIVATE -Wall -Wextra -Werror)
+add_test(NAME audio_underflow_tests COMMAND audio_underflow_tests)
+
 add_executable(deterministic_render_test deterministic_render_test.cpp)
 target_link_libraries(deterministic_render_test PRIVATE GTest::gtest_main)
 target_compile_options(deterministic_render_test PRIVATE -Wall -Wextra -Werror)

--- a/tests/audio_underflow_tests.cpp
+++ b/tests/audio_underflow_tests.cpp
@@ -1,0 +1,44 @@
+#include <gtest/gtest.h>
+
+#include <array>
+#include <vector>
+
+#include "avs/audio_portaudio_internal.hpp"
+
+namespace {
+
+TEST(ProcessCallbackInputTest, WritesSamplesAndAdvancesIndex) {
+  std::vector<float> ring(8, -1.0f);
+  const size_t mask = ring.size() - 1;
+  const size_t writeIndex = 2;
+  const std::array<float, 4> input{1.0f, -0.5f, 0.25f, 0.75f};
+
+  auto result = avs::portaudio_detail::processCallbackInput(input.data(), input.size(), writeIndex,
+                                                            mask, ring);
+
+  EXPECT_EQ(result.nextWriteIndex, writeIndex + input.size());
+  EXPECT_FALSE(result.underflow);
+  for (size_t i = 0; i < input.size(); ++i) {
+    const size_t idx = (writeIndex + i) & mask;
+    EXPECT_FLOAT_EQ(ring[idx], input[i]);
+  }
+}
+
+TEST(ProcessCallbackInputTest, NullInputMarksUnderflowAndZeroFills) {
+  std::vector<float> ring(8, 1.0f);
+  const size_t mask = ring.size() - 1;
+  const size_t writeIndex = 6;
+  const size_t sampleCount = 5;
+
+  auto result =
+      avs::portaudio_detail::processCallbackInput(nullptr, sampleCount, writeIndex, mask, ring);
+
+  EXPECT_EQ(result.nextWriteIndex, writeIndex + sampleCount);
+  EXPECT_TRUE(result.underflow);
+  for (size_t i = 0; i < sampleCount; ++i) {
+    const size_t idx = (writeIndex + i) & mask;
+    EXPECT_FLOAT_EQ(ring[idx], 0.0f);
+  }
+}
+
+}  // namespace


### PR DESCRIPTION
### Summary
Closes: #[issue-number] • Job: [Codex:engine-pa-underflow-surfacing]

- add dedicated audio_underflow_tests exercising processCallbackInput ring writes and underflow flagging
- register the new test target with ctest so the helper is covered in CI

### Checklist
- [x] Steps completed (map each step to a commit or note)
- [x] Acceptance criteria satisfied
- [ ] Tests added/updated and passing (`ctest`)
- [x] Warnings treated as errors (`-Werror`) clean
- [x] No binary blobs committed
- [x] If binaries required for review, ZIP artifact attached (name: `binary-assets-<branch>.zip`)

### Notes
- deterministic_render_test currently fails locally because the golden hashes under tests/golden/phase1 are not present in this workspace.


------
https://chatgpt.com/codex/tasks/task_e_68d2650a00fc832c8860a6d7f9c620d1