### PR TITLE
Fix avs-core build warnings and clean up headless sample

### DIFF
--- a/libs/avs-core/include/avs/params.hpp
+++ b/libs/avs-core/include/avs/params.hpp
@@ -1,9 +1,11 @@
 #pragma once
+#include <optional>
 #include <string>
 #include <string_view>
+#include <utility>
 #include <variant>
 #include <vector>
-#include <optional>
+
 #include "core.hpp"
 
 namespace avs {
@@ -16,13 +18,9 @@ struct OptionItem {
   std::string label;  // display
 };
 
-using ParamValue = std::variant<
-  bool, int, float, std::string, ColorRGBA8
->;
+using ParamValue = std::variant<bool, int, float, std::string, ColorRGBA8>;
 
-enum class ParamKind : uint8_t {
-  Bool, Int, Float, Color, String, Select, Resource, List
-};
+enum class ParamKind : uint8_t { Bool, Int, Float, Color, String, Select, Resource, List };
 
 struct Param {
   std::string name;
@@ -31,7 +29,21 @@ struct Param {
   // Optional constraints
   std::optional<int> i_min, i_max;
   std::optional<float> f_min, f_max;
-  std::vector<OptionItem> options; // for Select
+  std::vector<OptionItem> options;  // for Select
+
+  Param() = default;
+  Param(std::string name_, ParamKind kind_, ParamValue value_,
+        std::optional<int> i_min_ = std::nullopt, std::optional<int> i_max_ = std::nullopt,
+        std::optional<float> f_min_ = std::nullopt, std::optional<float> f_max_ = std::nullopt,
+        std::vector<OptionItem> options_ = {})
+      : name(std::move(name_)),
+        kind(kind_),
+        value(std::move(value_)),
+        i_min(std::move(i_min_)),
+        i_max(std::move(i_max_)),
+        f_min(std::move(f_min_)),
+        f_max(std::move(f_max_)),
+        options(std::move(options_)) {}
 };
 
 // A list-param can hold children; keep a flat array keyed by prefix paths, or
@@ -40,4 +52,4 @@ struct ParamList {
   std::vector<Param> items;
 };
 
-} // namespace avs
+}  // namespace avs

--- a/libs/avs-core/src/effects_render.cpp
+++ b/libs/avs-core/src/effects_render.cpp
@@ -1,96 +1,125 @@
 #include "avs/effects_render.hpp"
-#include "avs/core.hpp"
-#include "avs/params.hpp"
+
+#include <algorithm>
 #include <cmath>
 #include <random>
-#include <algorithm>
+
+#include "avs/core.hpp"
+#include "avs/params.hpp"
 
 namespace avs {
 
 // Utility to set a pixel in RGBA8 buffer safely.
-static inline void put_px(FrameBufferView& fb, int x, int y, const ColorRGBA8& c){
-  if(x < 0 || y < 0 || x >= fb.width || y >= fb.height) return;
+static inline void put_px(FrameBufferView& fb, int x, int y, const ColorRGBA8& c) {
+  if (x < 0 || y < 0 || x >= fb.width || y >= fb.height) return;
   uint8_t* p = fb.data + y * fb.stride + x * 4;
-  p[0] = c.r; p[1] = c.g; p[2] = c.b; p[3] = c.a;
+  p[0] = c.r;
+  p[1] = c.g;
+  p[2] = c.b;
+  p[3] = c.a;
 }
 
-static inline void line(FrameBufferView& fb, int x0, int y0, int x1, int y1, const ColorRGBA8& c){
+static inline void line(FrameBufferView& fb, int x0, int y0, int x1, int y1, const ColorRGBA8& c) {
   int dx = std::abs(x1 - x0), sx = x0 < x1 ? 1 : -1;
   int dy = -std::abs(y1 - y0), sy = y0 < y1 ? 1 : -1;
   int err = dx + dy, e2;
-  for(;;){
+  for (;;) {
     put_px(fb, x0, y0, c);
-    if(x0 == x1 && y0 == y1) break;
+    if (x0 == x1 && y0 == y1) break;
     e2 = 2 * err;
-    if(e2 >= dy){ err += dy; x0 += sx; }
-    if(e2 <= dx){ err += dx; y0 += sy; }
+    if (e2 >= dy) {
+      err += dy;
+      x0 += sx;
+    }
+    if (e2 <= dx) {
+      err += dx;
+      y0 += sy;
+    }
   }
 }
 
 // ---------------- Oscilloscope ----------------
 std::vector<Param> OscilloscopeEffect::parameters() const {
-  return {
-    {"source", ParamKind::Select, std::string("Mix")},
-    {"draw_mode", ParamKind::Select, std::string("Lines")},
-    {"thickness", ParamKind::Int, 1, 1, 8},
-    {"color", ParamKind::Color, ColorRGBA8{255,255,255,255}},
-    {"alpha", ParamKind::Float, 1.0f, {}, {}, {} ,},
-    {"smoothing", ParamKind::Float, 0.0f, 0.0f, 1.0f}
-  };
+  return {Param{"source",
+                ParamKind::Select,
+                std::string{"Mix"},
+                std::nullopt,
+                std::nullopt,
+                std::nullopt,
+                std::nullopt,
+                {{"left", "Left"}, {"right", "Right"}, {"mix", "Mix"}}},
+          Param{"draw_mode",
+                ParamKind::Select,
+                std::string{"Lines"},
+                std::nullopt,
+                std::nullopt,
+                std::nullopt,
+                std::nullopt,
+                {{"lines", "Lines"}, {"dots", "Dots"}}},
+          Param{"thickness", ParamKind::Int, 1, 1, 8},
+          Param{"color", ParamKind::Color, ColorRGBA8{255, 255, 255, 255}},
+          Param{"alpha", ParamKind::Float, 1.0f, std::nullopt, std::nullopt, 0.0f, 1.0f},
+          Param{"smoothing", ParamKind::Float, 0.0f, std::nullopt, std::nullopt, 0.0f, 1.0f}};
 }
 
-void OscilloscopeEffect::process(const ProcessContext& ctx, FrameBufferView& dst){
+void OscilloscopeEffect::process(const ProcessContext& ctx, FrameBufferView& dst) {
   // Basic polyline oscilloscope using Mix channel.
   const auto& af = ctx.audio;
   const auto& wave = (af.oscL.size() >= af.oscR.size()) ? af.oscL : af.oscR;
-  if(wave.empty()) return;
-  ColorRGBA8 col{255,255,255,255};
+  if (wave.empty()) return;
+  ColorRGBA8 col{255, 255, 255, 255};
   int W = dst.width, H = dst.height;
-  int prevx = 0, prevy = H/2;
-  for(int x=0; x<W; ++x){
-    size_t idx = (size_t)((x / (float)W) * (wave.size()-1));
-    float v = wave[idx]; // -1..1
-    int y = (int)((0.5f - 0.5f * v) * (H-1));
-    if(x > 0) line(dst, prevx, prevy, x, y, col);
-    prevx = x; prevy = y;
+  int prevx = 0, prevy = H / 2;
+  for (int x = 0; x < W; ++x) {
+    size_t idx = (size_t)((x / (float)W) * (wave.size() - 1));
+    float v = wave[idx];  // -1..1
+    int y = (int)((0.5f - 0.5f * v) * (H - 1));
+    if (x > 0) line(dst, prevx, prevy, x, y, col);
+    prevx = x;
+    prevy = y;
   }
 }
 
 // ---------------- Spectrum Analyzer (stub) ----------------
 std::vector<Param> SpectrumAnalyzerEffect::parameters() const {
-  return {
-    {"scale", ParamKind::Select, std::string("Linear")},
-    {"falloff", ParamKind::Float, 0.2f, 0.0f, 1.0f},
-    {"color", ParamKind::Color, ColorRGBA8{180,220,255,255}},
-    {"bars", ParamKind::Int, 64, 32, 512},
-    {"alpha", ParamKind::Float, 1.0f, 0.0f, 1.0f}
-  };
+  return {Param{"scale",
+                ParamKind::Select,
+                std::string{"Linear"},
+                std::nullopt,
+                std::nullopt,
+                std::nullopt,
+                std::nullopt,
+                {{"linear", "Linear"}, {"log", "Log"}}},
+          Param{"falloff", ParamKind::Float, 0.2f, std::nullopt, std::nullopt, 0.0f, 1.0f},
+          Param{"color", ParamKind::Color, ColorRGBA8{180, 220, 255, 255}},
+          Param{"bars", ParamKind::Int, 64, 32, 512},
+          Param{"alpha", ParamKind::Float, 1.0f, std::nullopt, std::nullopt, 0.0f, 1.0f}};
 }
 
-void SpectrumAnalyzerEffect::process(const ProcessContext& ctx, FrameBufferView& dst){
+void SpectrumAnalyzerEffect::process(const ProcessContext& ctx, FrameBufferView& dst) {
   // Draw simple bars from spectrum magnitudes; if empty, generate from osc as fallback.
   int W = dst.width, H = dst.height;
   int bars = 64;
   std::vector<float> mags;
-  if(!ctx.audio.spectrum.left.empty()){
+  if (!ctx.audio.spectrum.left.empty()) {
     mags = ctx.audio.spectrum.left;
-  }else if(!ctx.audio.oscL.empty()){
+  } else if (!ctx.audio.oscL.empty()) {
     // crude fallback
     mags.resize(bars);
-    for(int i=0;i<bars;i++){
-      float t = (float)i/(bars-1);
-      mags[i] = 0.5f*(1.0f + std::sin((ctx.time.t_seconds*2 + t*10)*3.14159f));
+    for (int i = 0; i < bars; i++) {
+      float t = (float)i / (bars - 1);
+      mags[i] = 0.5f * (1.0f + std::sin((ctx.time.t_seconds * 2 + t * 10) * 3.14159f));
     }
-  }else{
+  } else {
     return;
   }
   int bw = std::max(1, W / (int)mags.size());
-  for(size_t i=0;i<mags.size();++i){
-    int h = (int)(std::clamp(mags[i], 0.0f, 1.0f) * (H-1));
+  for (size_t i = 0; i < mags.size(); ++i) {
+    int h = (int)(std::clamp(mags[i], 0.0f, 1.0f) * (H - 1));
     int x0 = (int)(i * bw);
-    for(int y=H-1; y>=H-1-h; --y){
-      for(int x=x0; x<std::min(W, x0 + bw - 1); ++x){
-        put_px(dst, x, y, ColorRGBA8{180,220,255,255});
+    for (int y = H - 1; y >= H - 1 - h; --y) {
+      for (int x = x0; x < std::min(W, x0 + bw - 1); ++x) {
+        put_px(dst, x, y, ColorRGBA8{180, 220, 255, 255});
       }
     }
   }
@@ -98,63 +127,80 @@ void SpectrumAnalyzerEffect::process(const ProcessContext& ctx, FrameBufferView&
 
 // ---------------- Dots/Lines ----------------
 std::vector<Param> DotsLinesEffect::parameters() const {
-  return {
-    {"count", ParamKind::Int, 512, 1, 4096},
-    {"distribution", ParamKind::Select, std::string("Random")},
-    {"color", ParamKind::Color, ColorRGBA8{255,255,255,255}},
-    {"thickness", ParamKind::Int, 1, 1, 8}
-  };
+  return {Param{"count", ParamKind::Int, 512, 1, 4096},
+          Param{"distribution",
+                ParamKind::Select,
+                std::string{"Random"},
+                std::nullopt,
+                std::nullopt,
+                std::nullopt,
+                std::nullopt,
+                {{"random", "Random"}, {"circle", "Circle"}, {"grid", "Grid"}}},
+          Param{"color", ParamKind::Color, ColorRGBA8{255, 255, 255, 255}},
+          Param{"thickness", ParamKind::Int, 1, 1, 8}};
 }
 
-void DotsLinesEffect::process(const ProcessContext& ctx, FrameBufferView& dst){
+void DotsLinesEffect::process(const ProcessContext& ctx, FrameBufferView& dst) {
   int W = dst.width, H = dst.height;
   int n = 512;
   // Deterministic seed on frame index for repeatability (demo only).
   std::minstd_rand rng(ctx.time.frame_index + 1337);
-  std::uniform_int_distribution<int> dx(0, W-1), dy(0, H-1);
-  for(int i=0;i<n;i++){
+  std::uniform_int_distribution<int> dx(0, W - 1), dy(0, H - 1);
+  for (int i = 0; i < n; i++) {
     int x = dx(rng), y = dy(rng);
-    put_px(dst, x, y, ColorRGBA8{255,255,255,255});
+    put_px(dst, x, y, ColorRGBA8{255, 255, 255, 255});
   }
 }
 
 // ---------------- Starfield ----------------
-struct Star { float x, y, z; };
+struct Star {
+  float x, y, z;
+};
 
 std::vector<Param> StarfieldEffect::parameters() const {
   return {
-    {"stars", ParamKind::Int, 1024, 64, 8192},
-    {"speed", ParamKind::Float, 1.0f, 0.0f, 5.0f},
-    {"warp_center", ParamKind::Float, 0.5f, 0.0f, 1.0f},
-    {"color", ParamKind::Color, ColorRGBA8{255,255,255,255}},
+      Param{"stars", ParamKind::Int, 1024, 64, 8192},
+      Param{"speed", ParamKind::Float, 1.0f, std::nullopt, std::nullopt, 0.0f, 5.0f},
+      Param{"warp_center", ParamKind::Float, 0.5f, std::nullopt, std::nullopt, 0.0f, 1.0f},
+      Param{"color", ParamKind::Color, ColorRGBA8{255, 255, 255, 255}},
   };
 }
 
 class StarfieldState {
-public:
+ public:
   std::vector<Star> stars;
   int w{0}, h{0};
 };
 
-static StarfieldState& state(){
-  static StarfieldState s; return s;
+static StarfieldState& state() {
+  static StarfieldState s;
+  return s;
 }
 
-void StarfieldEffect::process(const ProcessContext& ctx, FrameBufferView& dst){
+void StarfieldEffect::process(const ProcessContext& ctx, FrameBufferView& dst) {
   auto& S = state();
-  if(S.w != dst.width || S.h != dst.height || S.stars.empty()){
-    S.w = dst.width; S.h = dst.height;
+  const float dt = static_cast<float>(ctx.time.dt_seconds);
+  if (S.w != dst.width || S.h != dst.height || S.stars.empty()) {
+    S.w = dst.width;
+    S.h = dst.height;
     std::minstd_rand rng(42);
     std::uniform_real_distribution<float> U(-1.f, 1.f);
     S.stars.resize(1024);
-    for(auto& s: S.stars){ s.x = U(rng); s.y = U(rng); s.z = (float)(0.2 + (std::fabs(U(rng))*1.0)); }
+    for (auto& s : S.stars) {
+      s.x = U(rng);
+      s.y = U(rng);
+      s.z = (float)(0.2 + (std::fabs(U(rng)) * 1.0));
+    }
   }
   // Update and draw
-  for(auto& s: S.stars){
-    s.z -= 0.02f; if(s.z <= 0.01f){ s.z += 1.0f; }
-    int x = (int)((s.x / s.z) * (S.w/4) + S.w/2);
-    int y = (int)((s.y / s.z) * (S.h/4) + S.h/2);
-    put_px(dst, x, y, ColorRGBA8{255,255,255,255});
+  for (auto& s : S.stars) {
+    s.z -= 0.02f * std::max(dt * 60.0f, 0.0f);
+    if (s.z <= 0.01f) {
+      s.z += 1.0f;
+    }
+    int x = (int)((s.x / s.z) * (S.w / 4) + S.w / 2);
+    int y = (int)((s.y / s.z) * (S.h / 4) + S.h / 2);
+    put_px(dst, x, y, ColorRGBA8{255, 255, 255, 255});
   }
 }
 
@@ -179,4 +225,4 @@ void ShapesEffect::process(const ProcessContext&, FrameBufferView&) {}
 std::vector<Param> DotGridEffect::parameters() const { return {}; }
 void DotGridEffect::process(const ProcessContext&, FrameBufferView&) {}
 
-} // namespace avs
+}  // namespace avs

--- a/libs/avs-core/src/effects_trans.cpp
+++ b/libs/avs-core/src/effects_trans.cpp
@@ -1,17 +1,22 @@
 #include "avs/effects_trans.hpp"
-#include "avs/core.hpp"
+
 #include <algorithm>
+
+#include "avs/core.hpp"
 
 namespace avs {
 
 // Simple helpers
-static inline void for_each_pixel(FrameBufferView& fb, auto&& fn){
-  for(int y=0;y<fb.height;y++){
+static inline void for_each_pixel(FrameBufferView& fb, auto&& fn) {
+  for (int y = 0; y < fb.height; y++) {
     uint8_t* row = fb.data + y * fb.stride;
-    for(int x=0;x<fb.width;x++){
-      ColorRGBA8 c{row[x*4+0], row[x*4+1], row[x*4+2], row[x*4+3]};
-      fn(x,y,c);
-      row[x*4+0]=c.r; row[x*4+1]=c.g; row[x*4+2]=c.b; row[x*4+3]=c.a;
+    for (int x = 0; x < fb.width; x++) {
+      ColorRGBA8 c{row[x * 4 + 0], row[x * 4 + 1], row[x * 4 + 2], row[x * 4 + 3]};
+      fn(x, y, c);
+      row[x * 4 + 0] = c.r;
+      row[x * 4 + 1] = c.g;
+      row[x * 4 + 2] = c.b;
+      row[x * 4 + 3] = c.a;
     }
   }
 }
@@ -19,54 +24,70 @@ static inline void for_each_pixel(FrameBufferView& fb, auto&& fn){
 // Movement / Dynamic variants (stubs; require sampling prev using EEL code)
 void MovementEffect::init(const InitContext&) {}
 std::vector<Param> MovementEffect::parameters() const { return {}; }
-void MovementEffect::process(const ProcessContext& ctx, FrameBufferView& dst){
+void MovementEffect::process(const ProcessContext& ctx, FrameBufferView& dst) {
   // For now, copy previous to current (placeholder).
-  if(!ctx.fb.previous.data) return;
-  for(int y=0;y<dst.height;y++){
+  if (!ctx.fb.previous.data) return;
+  for (int y = 0; y < dst.height; y++) {
     const uint8_t* s = ctx.fb.previous.data + y * ctx.fb.previous.stride;
     uint8_t* d = dst.data + y * dst.stride;
-    std::copy(s, s + dst.width*4, d);
+    std::copy(s, s + dst.width * 4, d);
   }
 }
 
 void DynamicMovementEffect::init(const InitContext&) {}
 std::vector<Param> DynamicMovementEffect::parameters() const { return {}; }
-void DynamicMovementEffect::process(const ProcessContext& ctx, FrameBufferView& dst){ MovementEffect().process(ctx, dst); }
+void DynamicMovementEffect::process(const ProcessContext& ctx, FrameBufferView& dst) {
+  MovementEffect().process(ctx, dst);
+}
 
 void DynamicDistanceModifierEffect::init(const InitContext&) {}
 std::vector<Param> DynamicDistanceModifierEffect::parameters() const { return {}; }
-void DynamicDistanceModifierEffect::process(const ProcessContext& ctx, FrameBufferView& dst){ MovementEffect().process(ctx, dst); }
+void DynamicDistanceModifierEffect::process(const ProcessContext& ctx, FrameBufferView& dst) {
+  MovementEffect().process(ctx, dst);
+}
 
 void DynamicShiftEffect::init(const InitContext&) {}
 std::vector<Param> DynamicShiftEffect::parameters() const { return {}; }
-void DynamicShiftEffect::process(const ProcessContext& ctx, FrameBufferView& dst){ /* TODO */ }
+void DynamicShiftEffect::process(const ProcessContext& ctx, FrameBufferView& dst) {
+  (void)ctx;
+  (void)dst;
+}
 
-void ZoomRotateEffect::process(const ProcessContext& ctx, FrameBufferView& dst){ MovementEffect().process(ctx, dst); }
+void ZoomRotateEffect::process(const ProcessContext& ctx, FrameBufferView& dst) {
+  MovementEffect().process(ctx, dst);
+}
 std::vector<Param> ZoomRotateEffect::parameters() const { return {}; }
 
-void MirrorEffect::process(const ProcessContext& ctx, FrameBufferView& dst){ MovementEffect().process(ctx, dst); }
+void MirrorEffect::process(const ProcessContext& ctx, FrameBufferView& dst) {
+  MovementEffect().process(ctx, dst);
+}
 std::vector<Param> MirrorEffect::parameters() const { return {}; }
 
 // Convolution (stub)
-void Convolution3x3Effect::process(const ProcessContext& ctx, FrameBufferView& dst){
+void Convolution3x3Effect::process(const ProcessContext& ctx, FrameBufferView& dst) {
   // No-op placeholder
-  (void)ctx;(void)dst;
+  (void)ctx;
+  (void)dst;
 }
 std::vector<Param> Convolution3x3Effect::parameters() const { return {}; }
 
-void BlurBoxEffect::process(const ProcessContext& ctx, FrameBufferView& dst){
+void BlurBoxEffect::process(const ProcessContext& ctx, FrameBufferView& dst) {
   // No-op placeholder
-  (void)ctx;(void)dst;
+  (void)ctx;
+  (void)dst;
 }
 std::vector<Param> BlurBoxEffect::parameters() const { return {}; }
 
 // Color Map (stub)
-void ColorMapEffect::process(const ProcessContext& ctx, FrameBufferView& dst){ (void)ctx;(void)dst; }
+void ColorMapEffect::process(const ProcessContext& ctx, FrameBufferView& dst) {
+  (void)ctx;
+  (void)dst;
+}
 std::vector<Param> ColorMapEffect::parameters() const { return {}; }
 
 // Invert
-void InvertEffect::process(const ProcessContext&, FrameBufferView& dst){
-  for_each_pixel(dst, [&](int, int, ColorRGBA8& c){
+void InvertEffect::process(const ProcessContext&, FrameBufferView& dst) {
+  for_each_pixel(dst, [&](int, int, ColorRGBA8& c) {
     c.r = (uint8_t)(255 - c.r);
     c.g = (uint8_t)(255 - c.g);
     c.b = (uint8_t)(255 - c.b);
@@ -75,11 +96,12 @@ void InvertEffect::process(const ProcessContext&, FrameBufferView& dst){
 
 // Fadeout
 std::vector<Param> FadeoutEffect::parameters() const {
-  return { {"amount", ParamKind::Float, 0.04f, 0.0f, 1.0f} };
+  return {Param{"amount", ParamKind::Float, 0.04f, std::nullopt, std::nullopt, 0.0f, 1.0f}};
 }
-void FadeoutEffect::process(const ProcessContext& ctx, FrameBufferView& dst){
-  float amt = 0.04f;
-  for_each_pixel(dst, [&](int, int, ColorRGBA8& c){
+void FadeoutEffect::process(const ProcessContext& ctx, FrameBufferView& dst) {
+  const float dt = static_cast<float>(ctx.time.dt_seconds);
+  float amt = 0.04f * std::clamp(dt * 60.0f, 0.0f, 4.0f);
+  for_each_pixel(dst, [&](int, int, ColorRGBA8& c) {
     c.r = (uint8_t)(c.r * (1.0f - amt));
     c.g = (uint8_t)(c.g * (1.0f - amt));
     c.b = (uint8_t)(c.b * (1.0f - amt));
@@ -87,19 +109,34 @@ void FadeoutEffect::process(const ProcessContext& ctx, FrameBufferView& dst){
 }
 
 // Bump / Interferences / Fast Brightness / Grain / Interleave (stubs)
-void BumpEffect::process(const ProcessContext& ctx, FrameBufferView& dst){ (void)ctx;(void)dst; }
+void BumpEffect::process(const ProcessContext& ctx, FrameBufferView& dst) {
+  (void)ctx;
+  (void)dst;
+}
 std::vector<Param> BumpEffect::parameters() const { return {}; }
 
-void InterferencesEffect::process(const ProcessContext& ctx, FrameBufferView& dst){ (void)ctx;(void)dst; }
+void InterferencesEffect::process(const ProcessContext& ctx, FrameBufferView& dst) {
+  (void)ctx;
+  (void)dst;
+}
 std::vector<Param> InterferencesEffect::parameters() const { return {}; }
 
-void FastBrightnessEffect::process(const ProcessContext& ctx, FrameBufferView& dst){ (void)ctx;(void)dst; }
+void FastBrightnessEffect::process(const ProcessContext& ctx, FrameBufferView& dst) {
+  (void)ctx;
+  (void)dst;
+}
 std::vector<Param> FastBrightnessEffect::parameters() const { return {}; }
 
-void GrainEffect::process(const ProcessContext& ctx, FrameBufferView& dst){ (void)ctx;(void)dst; }
+void GrainEffect::process(const ProcessContext& ctx, FrameBufferView& dst) {
+  (void)ctx;
+  (void)dst;
+}
 std::vector<Param> GrainEffect::parameters() const { return {}; }
 
-void InterleaveEffect::process(const ProcessContext& ctx, FrameBufferView& dst){ (void)ctx;(void)dst; }
+void InterleaveEffect::process(const ProcessContext& ctx, FrameBufferView& dst) {
+  (void)ctx;
+  (void)dst;
+}
 std::vector<Param> InterleaveEffect::parameters() const { return {}; }
 
-} // namespace avs
+}  // namespace avs


### PR DESCRIPTION
## Summary
- add a dedicated `avs::Param` constructor so call sites no longer rely on aggregate initialization that triggered -Wmissing-field-initializers
- update render/transform effects to provide option lists, clamp ranges, and consume timing data to satisfy -Werror flags
- rewrite the headless sample driver to output valid PPM headers and instantiate effects via the registry

## Testing
- `cmake --build .`
- `ctest` *(fails: deterministic_render_test is missing golden hash assets in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f033254540832cb3d2b9e5647f97c6