### PR TITLE
fix: run apt install step with bash

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,7 @@ jobs:
             ${{ runner.os }}-${{ matrix.distro }}-pkg-
 
       - name: Install build dependencies
+        shell: bash
         run: |
           set -euo pipefail
           if [ "${{ matrix.distro }}" = "ubuntu" ]; then


### PR DESCRIPTION
## Summary
- ensure the dependency installation step in CI uses bash so `set -euo pipefail` works inside the container

## Testing
- not run (workflow configuration change only)


------
https://chatgpt.com/codex/tasks/task_e_68f073ba0e50832ca8a2c4f20c95418e