### PR TITLE
feat: add blend, overlay, and swizzle effects

### DIFF
--- a/docs/compat/manifest.yaml
+++ b/docs/compat/manifest.yaml
@@ -1,0 +1,67 @@
+effects:
+  blend:
+    status: implemented
+    ops: &blend_ops
+      - additive
+      - alpha
+      - alpha2
+      - alphaslide
+      - blend
+      - blendslide
+      - replace
+      - defaultblend
+      - defrendblend
+      - above
+      - below
+    notes: "Integer math with 8-bit saturation matches AVS 2.x behaviour."
+  overlay:
+    status: implemented
+    ops: *blend_ops
+    notes: "Constant background/foreground colors blended per pixel."
+  swizzle:
+    status: implemented
+    modes: [rgb, rbg, grb, gbr, brg, bgr]
+    notes: "Alpha preserved; permutations applied branchlessly per pixel."
+parser:
+  micro_preset:
+    status: available
+    ignores:
+      - BUTTON*
+      - CHECK*
+      - EDIT*
+      - SLIDER*
+      - RADIO*
+      - TAB1
+      - LIST1
+      - SCROLLBAR1
+      - HELPBTN
+      - CHOOSEFONT
+      - VIS_*
+      - L_*
+      - DEBUGREG_*
+      - EFFECTRECT
+      - EFFECTS
+      - EFNAME
+      - SETTINGS
+      - VERSTR
+      - TRANS_CHECK
+      - TRANS_SLIDER
+      - THREADSBORDER
+      - REMSEL
+      - EXCLUDE
+      - NEWRESET
+      - HRESET
+      - VRESET
+      - MAX
+      - OFF
+      - IN
+      - OUT
+      - SA
+      - QUAL*
+    output: "Vector of effect+ParamBlock pairs"
+    tests:
+      - tests/core/test_blend_ops.cpp
+goldens:
+  micro_blend_md5:
+    file: tests/golden/micro_blend_md5.txt
+    update_command: ./tools/update_goldens.sh

--- a/docs/effects/blend.md
+++ b/docs/effects/blend.md
@@ -1,0 +1,96 @@
+# Core blending and swizzle effects
+
+The modern effects core exposes deterministic CPU implementations of AVS's
+classic blending and channel swizzle operations. The `blend`, `overlay`, and
+`swizzle` effects are registered via `avs::effects::registerCoreEffects()` and
+share the `BlendOp` enum declared in
+`libs/avs/effects/include/avs/effects/blend_ops.hpp`.
+
+## Blend effect
+
+`blend` applies a single operation between the framebuffer contents and a
+constant foreground color. Parameters are supplied through
+`avs::core::ParamBlock` keys:
+
+| Key        | Type    | Default | Description |
+|------------|---------|---------|-------------|
+| `op`       | string  | `replace` | Blend operation token (case insensitive). |
+| `fg` / `foreground` | int | `0x000000` | Foreground RGB color encoded as `0x00RRGGBB`. |
+| `fg_alpha` | int | `255` | Optional alpha channel for the foreground color. |
+| `alpha`    | int | `255` | Alpha used by the `ALPHA` mode. |
+| `alpha2`   | int | `alpha` | Alpha used by the `ALPHA2` mode. |
+| `slide` / `blend` | int | `alpha` | Slider value used by `ALPHASLIDE` and `BLENDSLIDE`. |
+
+All parameters are clamped to the 8-bit range. The foreground color is blended
+into the existing framebuffer without allocating additional memory. Operations
+match the legacy DLL's behaviour:
+
+| Token | Behaviour |
+|-------|-----------|
+| `replace` | Replace destination with the foreground color. |
+| `additive` / `add` | Component-wise saturating addition. |
+| `blend` | 50/50 average (integer, rounded). |
+| `alphaslide` | Interpolate using the `slide` parameter (`0` → destination, `255` → source). |
+| `alpha` | Interpolate using `alpha`. |
+| `alpha2` | Interpolate using `alpha2`. |
+| `blendslide` | Alias for `alphaslide`. |
+| `defaultblend` | Alias for `blend`. |
+| `defrendblend` | Alias for `blend` (matches the render-list "default render blend"). |
+| `above` | Per-channel maximum. |
+| `below` | Per-channel minimum. |
+
+All math is performed with integer arithmetic that mirrors AVS's look-up-table
+implementation. Saturation uses branchless masks to preserve SIMD-friendly inner
+loops.
+
+## Overlay effect
+
+`overlay` blends two constant colors and writes the result across the entire
+framebuffer. Parameters mirror the `blend` effect with additional background
+color support:
+
+| Key        | Type    | Default | Description |
+|------------|---------|---------|-------------|
+| `op`       | string  | `replace` | Blend operation token. |
+| `bg` / `background` | int | `0x000000` | Background RGB color. |
+| `bg_alpha` | int | `255` | Optional background alpha. |
+| `fg` / `foreground` | int | `0x000000` | Overlay RGB color. |
+| `fg_alpha` | int | `255` | Optional overlay alpha. |
+| `alpha` / `alpha2` / `slide` | int | `255` | Same semantics as for `blend`. |
+
+The operation is evaluated per pixel by first seeding the background color and
+then applying the selected `BlendOp`.
+
+## Swizzle effect
+
+`swizzle` permutes RGB channels in-place. The `mode` (or `order`) parameter
+accepts the six permutations: `rgb`, `rbg`, `grb`, `gbr`, `brg`, `bgr`. Alpha is
+always preserved. The implementation computes the new channel tuple and writes
+it back once per pixel to avoid intermediate aliasing.
+
+## Micro preset parser
+
+`parseMicroPreset()` in `libs/avs/effects/src/micro_preset_parser.cpp` provides a
+lightweight text format for tests and tooling. Each line specifies an effect key
+followed by `key=value` assignments. Tokens that originate from Win32 UI
+resource dumps (e.g. `BUTTON1`, `CHECKBOX`, `VIS_*`) are ignored with a warning
+and never emit runtime nodes.
+
+Values support decimal and hexadecimal integers (`0x` or `#` prefixes), floats,
+and booleans (`true`/`false`, `on`/`off`, `yes`/`no`). Unknown tokens fall back to
+strings so presets remain forward compatible.
+
+## Golden tests
+
+`tests/core/test_blend_ops.cpp` drives the blend, overlay, and swizzle effects
+through the micro preset parser and validates the resulting framebuffers against
+MD5 hashes stored in `tests/golden/micro_blend_md5.txt`. Update the hashes after
+behaviour changes with:
+
+```bash
+./tools/update_goldens.sh
+```
+
+The script rebuilds `core_effects_tests` and reruns it with `UPDATE_GOLDENS=1` so
+the golden manifest is rewritten automatically.
+

--- a/libs/avs/effects/CMakeLists.txt
+++ b/libs/avs/effects/CMakeLists.txt
@@ -1,7 +1,12 @@
 add_library(avs-effects-core
+  src/Blend.cpp
   src/Clear.cpp
+  src/Overlay.cpp
   src/RegisterEffects.cpp
-  src/Zoom.cpp)
+  src/Swizzle.cpp
+  src/Zoom.cpp
+  src/micro_preset_parser.cpp
+  src/effects/blend_ops.cpp)
 
 target_link_libraries(avs-effects-core PUBLIC avs-core-runtime)
 

--- a/libs/avs/effects/include/avs/effects/Blend.hpp
+++ b/libs/avs/effects/include/avs/effects/Blend.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <array>
+#include <cstdint>
+
+#include "avs/core/IEffect.hpp"
+#include "avs/effects/blend_ops.hpp"
+
+namespace avs::effects {
+
+class Blend : public avs::core::IEffect {
+ public:
+  bool render(avs::core::RenderContext& context) override;
+  void setParams(const avs::core::ParamBlock& params) override;
+
+ private:
+  BlendOp op_ = BlendOp::Replace;
+  std::array<std::uint8_t, 4> foreground_{0, 0, 0, 255};
+  std::uint8_t alpha_ = 255;
+  std::uint8_t alpha2_ = 255;
+  std::uint8_t slide_ = 255;
+};
+
+}  // namespace avs::effects

--- a/libs/avs/effects/include/avs/effects/Overlay.hpp
+++ b/libs/avs/effects/include/avs/effects/Overlay.hpp
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <array>
+#include <cstdint>
+
+#include "avs/core/IEffect.hpp"
+#include "avs/effects/blend_ops.hpp"
+
+namespace avs::effects {
+
+class Overlay : public avs::core::IEffect {
+ public:
+  bool render(avs::core::RenderContext& context) override;
+  void setParams(const avs::core::ParamBlock& params) override;
+
+ private:
+  BlendOp op_ = BlendOp::Replace;
+  std::array<std::uint8_t, 4> background_{0, 0, 0, 255};
+  std::array<std::uint8_t, 4> foreground_{0, 0, 0, 255};
+  std::uint8_t alpha_ = 255;
+  std::uint8_t alpha2_ = 255;
+  std::uint8_t slide_ = 255;
+};
+
+}  // namespace avs::effects

--- a/libs/avs/effects/include/avs/effects/Swizzle.hpp
+++ b/libs/avs/effects/include/avs/effects/Swizzle.hpp
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <array>
+#include <cstdint>
+#include <string>
+
+#include "avs/core/IEffect.hpp"
+
+namespace avs::effects {
+
+enum class SwizzleMode {
+  RGB,
+  RBG,
+  GRB,
+  GBR,
+  BRG,
+  BGR,
+};
+
+class Swizzle : public avs::core::IEffect {
+ public:
+  bool render(avs::core::RenderContext& context) override;
+  void setParams(const avs::core::ParamBlock& params) override;
+
+ private:
+  SwizzleMode mode_ = SwizzleMode::RGB;
+  std::array<std::uint8_t, 3> order_{0, 1, 2};
+};
+
+}  // namespace avs::effects

--- a/libs/avs/effects/include/avs/effects/blend_ops.hpp
+++ b/libs/avs/effects/include/avs/effects/blend_ops.hpp
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <array>
+#include <cstdint>
+#include <optional>
+#include <string_view>
+
+namespace avs::effects {
+
+enum class BlendOp {
+  Additive,
+  Alpha,
+  Alpha2,
+  AlphaSlide,
+  Blend,
+  BlendSlide,
+  Replace,
+  DefaultBlend,
+  DefrendBlend,
+  Above,
+  Below,
+};
+
+struct BlendConfig {
+  std::uint8_t alpha = 255;
+  std::uint8_t alpha2 = 255;
+  std::uint8_t slide = 255;
+};
+
+std::optional<BlendOp> parseBlendOpToken(std::string_view token);
+BlendOp parseBlendOpOrDefault(std::string_view token, BlendOp fallback);
+
+void blendPixelInPlace(BlendOp op, const BlendConfig& config, std::uint8_t* dst,
+                       const std::uint8_t* src);
+
+std::array<std::uint8_t, 4> blendPixel(BlendOp op, const BlendConfig& config,
+                                       const std::array<std::uint8_t, 4>& dst,
+                                       const std::array<std::uint8_t, 4>& src);
+
+}  // namespace avs::effects

--- a/libs/avs/effects/include/avs/effects/micro_preset_parser.hpp
+++ b/libs/avs/effects/include/avs/effects/micro_preset_parser.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "avs/core/ParamBlock.hpp"
+
+namespace avs::effects {
+
+struct MicroEffectCommand {
+  std::string effectKey;
+  avs::core::ParamBlock params;
+};
+
+struct MicroPreset {
+  std::vector<MicroEffectCommand> commands;
+  std::vector<std::string> warnings;
+};
+
+MicroPreset parseMicroPreset(std::string_view text);
+
+}  // namespace avs::effects

--- a/libs/avs/effects/src/Blend.cpp
+++ b/libs/avs/effects/src/Blend.cpp
@@ -1,0 +1,46 @@
+#include "avs/effects/Blend.hpp"
+
+namespace {
+std::array<std::uint8_t, 4> colorFromInt(int value, std::uint8_t alphaDefault) {
+  const std::uint32_t v = static_cast<std::uint32_t>(value);
+  return {static_cast<std::uint8_t>((v >> 16) & 0xFFu), static_cast<std::uint8_t>((v >> 8) & 0xFFu),
+          static_cast<std::uint8_t>(v & 0xFFu), alphaDefault};
+}
+
+std::uint8_t clampByte(int value) {
+  return static_cast<std::uint8_t>(value < 0 ? 0 : (value > 255 ? 255 : value));
+}
+}  // namespace
+
+namespace avs::effects {
+
+bool Blend::render(avs::core::RenderContext& context) {
+  if (!context.framebuffer.data || context.framebuffer.size == 0) {
+    return true;
+  }
+  BlendConfig config;
+  config.alpha = alpha_;
+  config.alpha2 = alpha2_;
+  config.slide = slide_;
+  std::uint8_t* data = context.framebuffer.data;
+  const std::size_t size = context.framebuffer.size;
+  for (std::size_t offset = 0; offset + 3 < size; offset += 4) {
+    blendPixelInPlace(op_, config, data + offset, foreground_.data());
+  }
+  return true;
+}
+
+void Blend::setParams(const avs::core::ParamBlock& params) {
+  const std::string opToken = params.getString("op", params.getString("mode", "replace"));
+  op_ = parseBlendOpOrDefault(opToken, BlendOp::Replace);
+
+  const int fgValue = params.getInt("fg", params.getInt("foreground", 0));
+  const int fgAlpha = params.getInt("fg_alpha", 255);
+  foreground_ = colorFromInt(fgValue, clampByte(fgAlpha));
+
+  alpha_ = clampByte(params.getInt("alpha", 255));
+  alpha2_ = clampByte(params.getInt("alpha2", params.getInt("alpha_2", alpha_)));
+  slide_ = clampByte(params.getInt("slide", params.getInt("blend", alpha_)));
+}
+
+}  // namespace avs::effects

--- a/libs/avs/effects/src/Overlay.cpp
+++ b/libs/avs/effects/src/Overlay.cpp
@@ -1,0 +1,52 @@
+#include "avs/effects/Overlay.hpp"
+
+#include <algorithm>
+
+namespace {
+std::array<std::uint8_t, 4> colorFromInt(int value, std::uint8_t alphaDefault) {
+  const std::uint32_t v = static_cast<std::uint32_t>(value);
+  return {static_cast<std::uint8_t>((v >> 16) & 0xFFu), static_cast<std::uint8_t>((v >> 8) & 0xFFu),
+          static_cast<std::uint8_t>(v & 0xFFu), alphaDefault};
+}
+
+std::uint8_t clampByte(int value) {
+  return static_cast<std::uint8_t>(value < 0 ? 0 : (value > 255 ? 255 : value));
+}
+}  // namespace
+
+namespace avs::effects {
+
+bool Overlay::render(avs::core::RenderContext& context) {
+  if (!context.framebuffer.data || context.framebuffer.size == 0) {
+    return true;
+  }
+  BlendConfig config;
+  config.alpha = alpha_;
+  config.alpha2 = alpha2_;
+  config.slide = slide_;
+  const auto blended = blendPixel(op_, config, background_, foreground_);
+  std::uint8_t* data = context.framebuffer.data;
+  const std::size_t size = context.framebuffer.size;
+  for (std::size_t offset = 0; offset + 3 < size; offset += 4) {
+    std::copy(blended.begin(), blended.end(), data + offset);
+  }
+  return true;
+}
+
+void Overlay::setParams(const avs::core::ParamBlock& params) {
+  const std::string opToken = params.getString("op", params.getString("mode", "replace"));
+  op_ = parseBlendOpOrDefault(opToken, BlendOp::Replace);
+
+  const int bgValue = params.getInt("bg", params.getInt("background", 0));
+  const int fgValue = params.getInt("fg", params.getInt("foreground", 0));
+  const int bgAlpha = params.getInt("bg_alpha", 255);
+  const int fgAlpha = params.getInt("fg_alpha", 255);
+  background_ = colorFromInt(bgValue, clampByte(bgAlpha));
+  foreground_ = colorFromInt(fgValue, clampByte(fgAlpha));
+
+  alpha_ = clampByte(params.getInt("alpha", 255));
+  alpha2_ = clampByte(params.getInt("alpha2", params.getInt("alpha_2", alpha_)));
+  slide_ = clampByte(params.getInt("slide", params.getInt("blend", alpha_)));
+}
+
+}  // namespace avs::effects

--- a/libs/avs/effects/src/RegisterEffects.cpp
+++ b/libs/avs/effects/src/RegisterEffects.cpp
@@ -2,7 +2,10 @@
 
 #include <memory>
 
+#include "avs/effects/Blend.hpp"
 #include "avs/effects/Clear.hpp"
+#include "avs/effects/Overlay.hpp"
+#include "avs/effects/Swizzle.hpp"
 #include "avs/effects/Zoom.hpp"
 
 namespace avs::effects {
@@ -10,6 +13,9 @@ namespace avs::effects {
 void registerCoreEffects(avs::core::EffectRegistry& registry) {
   registry.registerFactory("clear", []() { return std::make_unique<Clear>(); });
   registry.registerFactory("zoom", []() { return std::make_unique<Zoom>(); });
+  registry.registerFactory("blend", []() { return std::make_unique<Blend>(); });
+  registry.registerFactory("overlay", []() { return std::make_unique<Overlay>(); });
+  registry.registerFactory("swizzle", []() { return std::make_unique<Swizzle>(); });
 }
 
 }  // namespace avs::effects

--- a/libs/avs/effects/src/Swizzle.cpp
+++ b/libs/avs/effects/src/Swizzle.cpp
@@ -1,0 +1,65 @@
+#include "avs/effects/Swizzle.hpp"
+
+#include <algorithm>
+#include <array>
+#include <cctype>
+#include <string>
+
+namespace {
+
+avs::effects::SwizzleMode parseMode(const std::string& token) {
+  std::string lower(token);
+  std::transform(lower.begin(), lower.end(), lower.begin(),
+                 [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+  if (lower == "rgb") return avs::effects::SwizzleMode::RGB;
+  if (lower == "rbg") return avs::effects::SwizzleMode::RBG;
+  if (lower == "grb") return avs::effects::SwizzleMode::GRB;
+  if (lower == "gbr") return avs::effects::SwizzleMode::GBR;
+  if (lower == "brg") return avs::effects::SwizzleMode::BRG;
+  if (lower == "bgr") return avs::effects::SwizzleMode::BGR;
+  return avs::effects::SwizzleMode::RGB;
+}
+
+std::array<std::uint8_t, 3> orderForMode(avs::effects::SwizzleMode mode) {
+  switch (mode) {
+    case avs::effects::SwizzleMode::RGB:
+      return {0, 1, 2};
+    case avs::effects::SwizzleMode::RBG:
+      return {0, 2, 1};
+    case avs::effects::SwizzleMode::GRB:
+      return {1, 0, 2};
+    case avs::effects::SwizzleMode::GBR:
+      return {1, 2, 0};
+    case avs::effects::SwizzleMode::BRG:
+      return {2, 0, 1};
+    case avs::effects::SwizzleMode::BGR:
+      return {2, 1, 0};
+  }
+  return {0, 1, 2};
+}
+}  // namespace
+
+namespace avs::effects {
+
+bool Swizzle::render(avs::core::RenderContext& context) {
+  if (!context.framebuffer.data || context.framebuffer.size == 0) {
+    return true;
+  }
+  std::uint8_t* data = context.framebuffer.data;
+  const std::size_t size = context.framebuffer.size;
+  for (std::size_t offset = 0; offset + 3 < size; offset += 4) {
+    const std::uint8_t original[3] = {data[offset + 0], data[offset + 1], data[offset + 2]};
+    data[offset + 0] = original[order_[0]];
+    data[offset + 1] = original[order_[1]];
+    data[offset + 2] = original[order_[2]];
+  }
+  return true;
+}
+
+void Swizzle::setParams(const avs::core::ParamBlock& params) {
+  const std::string modeToken = params.getString("mode", params.getString("order", "rgb"));
+  mode_ = parseMode(modeToken);
+  order_ = orderForMode(mode_);
+}
+
+}  // namespace avs::effects

--- a/libs/avs/effects/src/effects/blend_ops.cpp
+++ b/libs/avs/effects/src/effects/blend_ops.cpp
@@ -1,0 +1,180 @@
+#include "avs/effects/blend_ops.hpp"
+
+#include <algorithm>
+#include <array>
+#include <cctype>
+#include <cstddef>
+#include <string>
+
+namespace avs::effects {
+namespace {
+
+inline std::uint8_t saturatingAdd(std::uint8_t a, std::uint8_t b) {
+  const std::uint16_t sum = static_cast<std::uint16_t>(a) + static_cast<std::uint16_t>(b);
+  const std::uint16_t mask = static_cast<std::uint16_t>(-static_cast<std::int16_t>(sum > 255));
+  return static_cast<std::uint8_t>((sum & 0xFFu) | (mask & 0xFFu));
+}
+
+inline std::uint8_t average(std::uint8_t a, std::uint8_t b) {
+  return static_cast<std::uint8_t>((a >> 1) + (b >> 1));
+}
+
+inline std::uint8_t blendTable(std::uint8_t value, std::uint8_t weight) {
+  return static_cast<std::uint8_t>(
+      (static_cast<std::uint32_t>(value) * static_cast<std::uint32_t>(weight)) / 255u);
+}
+
+inline std::uint8_t blendAdjust(std::uint8_t dst, std::uint8_t src, std::uint8_t alpha) {
+  const std::uint8_t inv = static_cast<std::uint8_t>(255u - alpha);
+  return static_cast<std::uint8_t>(blendTable(src, alpha) + blendTable(dst, inv));
+}
+
+inline std::uint8_t channelMax(std::uint8_t a, std::uint8_t b) {
+  const std::uint8_t mask = static_cast<std::uint8_t>(-static_cast<std::int8_t>(a < b));
+  return static_cast<std::uint8_t>(a ^ ((a ^ b) & mask));
+}
+
+inline std::uint8_t channelMin(std::uint8_t a, std::uint8_t b) {
+  const std::uint8_t mask = static_cast<std::uint8_t>(-static_cast<std::int8_t>(a < b));
+  return static_cast<std::uint8_t>(b ^ ((a ^ b) & mask));
+}
+
+template <typename Func>
+inline void applyChannels(std::uint8_t* dst, const std::uint8_t* src, Func&& func) {
+  dst[0] = func(dst[0], src[0]);
+  dst[1] = func(dst[1], src[1]);
+  dst[2] = func(dst[2], src[2]);
+  dst[3] = func(dst[3], src[3]);
+}
+
+void applyReplace(const BlendConfig&, std::uint8_t* dst, const std::uint8_t* src) {
+  dst[0] = src[0];
+  dst[1] = src[1];
+  dst[2] = src[2];
+  dst[3] = src[3];
+}
+
+void applyAdditive(const BlendConfig&, std::uint8_t* dst, const std::uint8_t* src) {
+  applyChannels(dst, src, [](std::uint8_t d, std::uint8_t s) { return saturatingAdd(d, s); });
+}
+
+void applyBlend(const BlendConfig&, std::uint8_t* dst, const std::uint8_t* src) {
+  applyChannels(dst, src, [](std::uint8_t d, std::uint8_t s) { return average(d, s); });
+}
+
+void applyAlpha(const BlendConfig& config, std::uint8_t* dst, const std::uint8_t* src) {
+  const std::uint8_t alpha = config.alpha;
+  applyChannels(dst, src,
+                [alpha](std::uint8_t d, std::uint8_t s) { return blendAdjust(d, s, alpha); });
+}
+
+void applyAlpha2(const BlendConfig& config, std::uint8_t* dst, const std::uint8_t* src) {
+  const std::uint8_t alpha = config.alpha2;
+  applyChannels(dst, src,
+                [alpha](std::uint8_t d, std::uint8_t s) { return blendAdjust(d, s, alpha); });
+}
+
+void applyAlphaSlide(const BlendConfig& config, std::uint8_t* dst, const std::uint8_t* src) {
+  const std::uint8_t alpha = config.slide;
+  applyChannels(dst, src,
+                [alpha](std::uint8_t d, std::uint8_t s) { return blendAdjust(d, s, alpha); });
+}
+
+void applyAbove(const BlendConfig&, std::uint8_t* dst, const std::uint8_t* src) {
+  applyChannels(dst, src, [](std::uint8_t d, std::uint8_t s) { return channelMax(d, s); });
+}
+
+void applyBelow(const BlendConfig&, std::uint8_t* dst, const std::uint8_t* src) {
+  applyChannels(dst, src, [](std::uint8_t d, std::uint8_t s) { return channelMin(d, s); });
+}
+
+using PixelFunc = void (*)(const BlendConfig&, std::uint8_t*, const std::uint8_t*);
+
+constexpr std::array<PixelFunc, 11> kDispatch = {
+    applyAdditive,    // Additive
+    applyAlpha,       // Alpha
+    applyAlpha2,      // Alpha2
+    applyAlphaSlide,  // AlphaSlide
+    applyBlend,       // Blend
+    applyAlphaSlide,  // BlendSlide
+    applyReplace,     // Replace
+    applyBlend,       // DefaultBlend
+    applyBlend,       // DefrendBlend
+    applyAbove,       // Above
+    applyBelow,       // Below
+};
+
+static_assert(static_cast<std::size_t>(BlendOp::Below) == kDispatch.size() - 1,
+              "BlendOp dispatch table out of sync");
+
+std::string toLower(std::string_view token) {
+  std::string result(token);
+  std::transform(result.begin(), result.end(), result.begin(),
+                 [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+  return result;
+}
+
+}  // namespace
+
+std::optional<BlendOp> parseBlendOpToken(std::string_view token) {
+  const std::string lower = toLower(token);
+  if (lower == "add" || lower == "additive") {
+    return BlendOp::Additive;
+  }
+  if (lower == "alpha") {
+    return BlendOp::Alpha;
+  }
+  if (lower == "alpha2" || lower == "alpha_2") {
+    return BlendOp::Alpha2;
+  }
+  if (lower == "alphaslide" || lower == "alpha_slide" || lower == "alpha-slide") {
+    return BlendOp::AlphaSlide;
+  }
+  if (lower == "blend") {
+    return BlendOp::Blend;
+  }
+  if (lower == "blendslide" || lower == "blend_slide" || lower == "blend-slide") {
+    return BlendOp::BlendSlide;
+  }
+  if (lower == "replace") {
+    return BlendOp::Replace;
+  }
+  if (lower == "default" || lower == "defaultblend" || lower == "defblend") {
+    return BlendOp::DefaultBlend;
+  }
+  if (lower == "defrend" || lower == "defrendblend" || lower == "defaultrenderblend" ||
+      lower == "renderblend") {
+    return BlendOp::DefrendBlend;
+  }
+  if (lower == "above") {
+    return BlendOp::Above;
+  }
+  if (lower == "below") {
+    return BlendOp::Below;
+  }
+  return std::nullopt;
+}
+
+BlendOp parseBlendOpOrDefault(std::string_view token, BlendOp fallback) {
+  if (auto op = parseBlendOpToken(token)) {
+    return *op;
+  }
+  return fallback;
+}
+
+void blendPixelInPlace(BlendOp op, const BlendConfig& config, std::uint8_t* dst,
+                       const std::uint8_t* src) {
+  const auto index = static_cast<std::size_t>(op);
+  kDispatch[index](config, dst, src);
+}
+
+std::array<std::uint8_t, 4> blendPixel(BlendOp op, const BlendConfig& config,
+                                       const std::array<std::uint8_t, 4>& dst,
+                                       const std::array<std::uint8_t, 4>& src) {
+  auto result = dst;
+  const auto index = static_cast<std::size_t>(op);
+  kDispatch[index](config, result.data(), src.data());
+  return result;
+}
+
+}  // namespace avs::effects

--- a/libs/avs/effects/src/micro_preset_parser.cpp
+++ b/libs/avs/effects/src/micro_preset_parser.cpp
@@ -1,0 +1,205 @@
+#include "avs/effects/micro_preset_parser.hpp"
+
+#include <algorithm>
+#include <cctype>
+#include <charconv>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+
+namespace {
+
+std::string trimCopy(std::string_view text) {
+  std::size_t begin = 0;
+  while (begin < text.size() && std::isspace(static_cast<unsigned char>(text[begin]))) {
+    ++begin;
+  }
+  std::size_t end = text.size();
+  while (end > begin && std::isspace(static_cast<unsigned char>(text[end - 1]))) {
+    --end;
+  }
+  return std::string(text.substr(begin, end - begin));
+}
+
+std::string toLower(std::string_view text) {
+  std::string result(text);
+  std::transform(result.begin(), result.end(), result.begin(),
+                 [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+  return result;
+}
+
+std::string toUpper(std::string_view text) {
+  std::string result(text);
+  std::transform(result.begin(), result.end(), result.begin(),
+                 [](unsigned char c) { return static_cast<char>(std::toupper(c)); });
+  return result;
+}
+
+struct UiPattern {
+  std::string token;
+  bool prefix;
+};
+
+bool isUiToken(const std::string& tokenUpper) {
+  static const UiPattern patterns[] = {
+      {"BUTTON", true},       {"CHECK", true},         {"EDIT", true},
+      {"SLIDER", true},       {"RADIO", true},         {"TAB1", false},
+      {"LIST1", false},       {"SCROLLBAR1", false},   {"HELPBTN", false},
+      {"CHOOSEFONT", false},  {"VIS_", true},          {"L_", true},
+      {"DEBUGREG_", true},    {"EFFECTRECT", false},   {"EFFECTS", false},
+      {"EFNAME", false},      {"SETTINGS", false},     {"VERSTR", false},
+      {"TRANS_CHECK", false}, {"TRANS_SLIDER", false}, {"THREADSBORDER", false},
+      {"REMSEL", false},      {"EXCLUDE", false},      {"NEWRESET", false},
+      {"HRESET", false},      {"VRESET", false},       {"MAX", false},
+      {"OFF", false},         {"IN", false},           {"OUT", false},
+      {"SA", false},          {"QUAL", true},
+  };
+  for (const auto& pattern : patterns) {
+    if (pattern.prefix) {
+      if (tokenUpper.rfind(pattern.token, 0) == 0) {
+        return true;
+      }
+    } else if (tokenUpper == pattern.token) {
+      return true;
+    }
+  }
+  return false;
+}
+
+std::vector<std::string> tokenize(std::string_view line) {
+  std::vector<std::string> tokens;
+  std::string current;
+  bool inQuote = false;
+  char quoteChar = '\0';
+  for (char ch : line) {
+    if (inQuote) {
+      if (ch == quoteChar) {
+        tokens.push_back(current);
+        current.clear();
+        inQuote = false;
+      } else {
+        current.push_back(ch);
+      }
+    } else if (std::isspace(static_cast<unsigned char>(ch))) {
+      if (!current.empty()) {
+        tokens.push_back(current);
+        current.clear();
+      }
+    } else if (ch == '"' || ch == 39) {
+      if (!current.empty()) {
+        tokens.push_back(current);
+        current.clear();
+      }
+      inQuote = true;
+      quoteChar = ch;
+    } else {
+      current.push_back(ch);
+    }
+  }
+  if (!current.empty()) {
+    tokens.push_back(current);
+  }
+  return tokens;
+}
+
+bool tryParseInt(const std::string& value, int base, int& out) {
+  const char* begin = value.c_str();
+  const char* end = begin + value.size();
+  std::from_chars_result result = std::from_chars(begin, end, out, base);
+  return result.ec == std::errc() && result.ptr == end;
+}
+
+void assignValue(avs::core::ParamBlock& params, const std::string& key, const std::string& value) {
+  if (value.empty()) {
+    params.setBool(key, true);
+    return;
+  }
+  const std::string lowerValue = toLower(value);
+  if (lowerValue == "true" || lowerValue == "on" || lowerValue == "yes") {
+    params.setBool(key, true);
+    return;
+  }
+  if (lowerValue == "false" || lowerValue == "off" || lowerValue == "no") {
+    params.setBool(key, false);
+    return;
+  }
+
+  std::string numeric = value;
+  int base = 10;
+  if (!numeric.empty() && numeric.front() == '#') {
+    numeric = numeric.substr(1);
+    base = 16;
+  } else if (numeric.size() > 2 && numeric[0] == '0' && (numeric[1] == 'x' || numeric[1] == 'X')) {
+    numeric = numeric.substr(2);
+    base = 16;
+  }
+
+  int parsedInt = 0;
+  if (!numeric.empty() && tryParseInt(numeric, base, parsedInt)) {
+    params.setInt(key, parsedInt);
+    return;
+  }
+
+  if (value.find('.') != std::string::npos) {
+    try {
+      float parsedFloat = std::stof(value);
+      params.setFloat(key, parsedFloat);
+      return;
+    } catch (...) {
+      // Fall through to string assignment.
+    }
+  }
+
+  params.setString(key, value);
+}
+
+}  // namespace
+
+namespace avs::effects {
+
+MicroPreset parseMicroPreset(std::string_view text) {
+  MicroPreset preset;
+  std::istringstream stream{std::string(text)};
+  std::string line;
+  while (std::getline(stream, line)) {
+    if (!line.empty() && line.back() == '\r') {
+      line.pop_back();
+    }
+    const auto commentPos = line.find('#');
+    if (commentPos != std::string::npos) {
+      line.erase(commentPos);
+    }
+    const std::string trimmed = trimCopy(line);
+    if (trimmed.empty()) {
+      continue;
+    }
+    const auto tokens = tokenize(trimmed);
+    if (tokens.empty()) {
+      continue;
+    }
+    const std::string effectToken = tokens.front();
+    const std::string effectUpper = toUpper(effectToken);
+    if (isUiToken(effectUpper)) {
+      preset.warnings.push_back("ignored token: " + effectToken);
+      continue;
+    }
+    MicroEffectCommand command;
+    command.effectKey = toLower(effectToken);
+    for (std::size_t i = 1; i < tokens.size(); ++i) {
+      const std::string& token = tokens[i];
+      const auto eqPos = token.find('=');
+      if (eqPos == std::string::npos) {
+        command.params.setBool(toLower(token), true);
+        continue;
+      }
+      std::string key = toLower(token.substr(0, eqPos));
+      std::string value = token.substr(eqPos + 1);
+      assignValue(command.params, key, value);
+    }
+    preset.commands.push_back(std::move(command));
+  }
+  return preset;
+}
+
+}  // namespace avs::effects

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -37,9 +37,11 @@ endif()
 
 add_executable(core_effects_tests
   core/test_effect_registry.cpp
-  core/test_pipeline.cpp)
-target_link_libraries(core_effects_tests PRIVATE avs-effects-core avs-core-runtime GTest::gtest_main)
+  core/test_pipeline.cpp
+  core/test_blend_ops.cpp)
+target_link_libraries(core_effects_tests PRIVATE avs-effects-core avs-core-runtime avs-offscreen GTest::gtest_main)
 target_compile_options(core_effects_tests PRIVATE -Wall -Wextra -Werror)
+target_compile_definitions(core_effects_tests PRIVATE BUILD_DIR="${CMAKE_BINARY_DIR}" SOURCE_DIR="${CMAKE_SOURCE_DIR}")
 add_test(NAME core_effects_tests COMMAND core_effects_tests)
 
 add_executable(runtime_resource_tests

--- a/tests/core/test_blend_ops.cpp
+++ b/tests/core/test_blend_ops.cpp
@@ -1,0 +1,243 @@
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <array>
+#include <cstdint>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <functional>
+#include <optional>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "avs/core/EffectRegistry.hpp"
+#include "avs/core/ParamBlock.hpp"
+#include "avs/core/Pipeline.hpp"
+#include "avs/core/RenderContext.hpp"
+#include "avs/effects/RegisterEffects.hpp"
+#include "avs/effects/blend_ops.hpp"
+#include "avs/effects/micro_preset_parser.hpp"
+#include "avs/offscreen/Md5.hpp"
+
+namespace {
+
+using avs::core::ParamBlock;
+using avs::core::RenderContext;
+using avs::effects::BlendOp;
+
+std::string loadFile(const std::filesystem::path& path) {
+  std::ifstream file(path);
+  if (!file) {
+    throw std::runtime_error("failed to open file: " + path.string());
+  }
+  std::ostringstream oss;
+  oss << file.rdbuf();
+  return oss.str();
+}
+
+RenderContext makeContext(std::vector<std::uint8_t>& pixels, int width, int height) {
+  RenderContext ctx;
+  ctx.frameIndex = 0;
+  ctx.deltaSeconds = 1.0 / 60.0;
+  ctx.width = width;
+  ctx.height = height;
+  ctx.framebuffer = {pixels.data(), pixels.size()};
+  ctx.audioSpectrum = {nullptr, 0};
+  return ctx;
+}
+
+class GoldenManager {
+ public:
+  static GoldenManager& instance() {
+    static GoldenManager manager;
+    return manager;
+  }
+
+  std::string expected(const std::string& key) const {
+    auto it = md5_.find(key);
+    if (it == md5_.end()) {
+      return {};
+    }
+    return it->second;
+  }
+
+  void set(const std::string& key, const std::string& value) {
+    md5_[key] = value;
+    if (updateMode_) {
+      write();
+    }
+  }
+
+  bool updateMode() const { return updateMode_; }
+
+ private:
+  GoldenManager() {
+    path_ = std::filesystem::path(SOURCE_DIR) / "tests/golden/micro_blend_md5.txt";
+    load();
+    updateMode_ = std::getenv("UPDATE_GOLDENS") != nullptr;
+  }
+
+  void load() {
+    std::ifstream file(path_);
+    if (!file) {
+      return;
+    }
+    std::string line;
+    while (std::getline(file, line)) {
+      auto hashPos = line.find('#');
+      if (hashPos != std::string::npos) {
+        line = line.substr(0, hashPos);
+      }
+      std::istringstream iss(line);
+      std::string name;
+      std::string md5;
+      if (!(iss >> name >> md5)) {
+        continue;
+      }
+      md5_[name] = md5;
+    }
+  }
+
+  void write() const {
+    std::vector<std::pair<std::string, std::string>> entries(md5_.begin(), md5_.end());
+    std::sort(entries.begin(), entries.end(),
+              [](const auto& a, const auto& b) { return a.first < b.first; });
+    std::ofstream file(path_, std::ios::trunc);
+    if (!file) {
+      throw std::runtime_error("failed to write golden file: " + path_.string());
+    }
+    file << "# name md5\n";
+    for (const auto& [name, md5] : entries) {
+      file << name << ' ' << md5 << "\n";
+    }
+  }
+
+  std::unordered_map<std::string, std::string> md5_;
+  std::filesystem::path path_;
+  bool updateMode_ = false;
+};
+
+void expectGolden(const std::string& key, const std::string& value) {
+  auto& golden = GoldenManager::instance();
+  if (golden.updateMode()) {
+    golden.set(key, value);
+  } else {
+    const auto expected = golden.expected(key);
+    ASSERT_FALSE(expected.empty()) << "Missing golden entry for " << key;
+    EXPECT_EQ(value, expected);
+  }
+}
+
+std::string renderMicroPreset(const std::string& key, const std::filesystem::path& presetPath,
+                              avs::core::EffectRegistry& registry,
+                              const std::function<void(std::vector<std::uint8_t>&)>& initializer) {
+  (void)key;
+  const std::string presetText = loadFile(presetPath);
+  const auto parsed = avs::effects::parseMicroPreset(presetText);
+
+  avs::core::Pipeline pipeline(registry);
+  for (const auto& command : parsed.commands) {
+    pipeline.add(command.effectKey, command.params);
+  }
+
+  constexpr int kWidth = 2;
+  constexpr int kHeight = 2;
+  std::vector<std::uint8_t> pixels(static_cast<std::size_t>(kWidth * kHeight * 4), 0);
+  initializer(pixels);
+  auto ctx = makeContext(pixels, kWidth, kHeight);
+  EXPECT_TRUE(pipeline.render(ctx));
+  return avs::offscreen::computeMd5Hex(pixels.data(), pixels.size());
+}
+
+std::string renderMicroPreset(const std::string& key, const std::filesystem::path& presetPath,
+                              avs::core::EffectRegistry& registry) {
+  return renderMicroPreset(key, presetPath, registry, [](std::vector<std::uint8_t>&) {});
+}
+
+}  // namespace
+
+TEST(BlendOpParser, ParsesBlendTokens) {
+  using avs::effects::parseBlendOpToken;
+  auto add = parseBlendOpToken("additive");
+  ASSERT_TRUE(add.has_value());
+  EXPECT_EQ(*add, BlendOp::Additive);
+
+  auto alpha2 = parseBlendOpToken("ALPHA2");
+  ASSERT_TRUE(alpha2.has_value());
+  EXPECT_EQ(*alpha2, BlendOp::Alpha2);
+
+  auto slide = parseBlendOpToken("BlendSlide");
+  ASSERT_TRUE(slide.has_value());
+  EXPECT_EQ(*slide, BlendOp::BlendSlide);
+
+  auto unknown = parseBlendOpToken("mystery");
+  EXPECT_FALSE(unknown.has_value());
+}
+
+TEST(MicroPresetParser, HandlesParametersAndUiTokens) {
+  const char* text = R"(BUTTON1 ignored
+blend op=alpha alpha=200 slide=42 fg=0x00ff00
+CHECKBOX extra
+)";
+  auto parsed = avs::effects::parseMicroPreset(text);
+  ASSERT_EQ(parsed.commands.size(), 1u);
+  const auto& cmd = parsed.commands.front();
+  EXPECT_EQ(cmd.effectKey, "blend");
+  EXPECT_EQ(cmd.params.getInt("alpha", 0), 200);
+  EXPECT_EQ(cmd.params.getInt("slide", 0), 42);
+  EXPECT_EQ(cmd.params.getInt("fg", 0), 0x00ff00);
+  ASSERT_FALSE(parsed.warnings.empty());
+}
+
+class BlendEffectsTest : public ::testing::Test {
+ protected:
+  BlendEffectsTest() { avs::effects::registerCoreEffects(registry_); }
+
+  avs::core::EffectRegistry registry_;
+};
+
+TEST_F(BlendEffectsTest, BlendAdditiveGolden) {
+  const auto md5 = renderMicroPreset(
+      "blend_additive",
+      std::filesystem::path(SOURCE_DIR) / "tests/data/micro_presets/blend_additive.txt", registry_);
+  expectGolden("blend_additive", md5);
+}
+
+TEST_F(BlendEffectsTest, BlendAlphaGolden) {
+  const auto md5 = renderMicroPreset(
+      "blend_alpha", std::filesystem::path(SOURCE_DIR) / "tests/data/micro_presets/blend_alpha.txt",
+      registry_);
+  expectGolden("blend_alpha", md5);
+}
+
+TEST_F(BlendEffectsTest, OverlayBlendSlideGolden) {
+  const auto md5 = renderMicroPreset(
+      "overlay_blendslide",
+      std::filesystem::path(SOURCE_DIR) / "tests/data/micro_presets/overlay_blendslide.txt",
+      registry_);
+  expectGolden("overlay_blendslide", md5);
+}
+
+TEST_F(BlendEffectsTest, SwizzleBgrGolden) {
+  const auto md5 = renderMicroPreset(
+      "swizzle_bgr", std::filesystem::path(SOURCE_DIR) / "tests/data/micro_presets/swizzle_bgr.txt",
+      registry_, [](std::vector<std::uint8_t>& pixels) {
+        const std::array<std::array<std::uint8_t, 4>, 4> gradient{{
+            {{0, 64, 128, 255}},
+            {{32, 96, 160, 255}},
+            {{64, 128, 192, 255}},
+            {{96, 160, 224, 255}},
+        }};
+        for (size_t i = 0; i < gradient.size(); ++i) {
+          std::copy(gradient[i].begin(), gradient[i].end(),
+                    pixels.begin() + static_cast<std::ptrdiff_t>(i * 4));
+        }
+      });
+  expectGolden("swizzle_bgr", md5);
+}

--- a/tests/data/micro_presets/blend_additive.txt
+++ b/tests/data/micro_presets/blend_additive.txt
@@ -1,0 +1,3 @@
+# Micro preset for additive blending: background red, foreground green
+overlay op=replace fg=0xff0000
+blend op=additive fg=0x00ff00

--- a/tests/data/micro_presets/blend_alpha.txt
+++ b/tests/data/micro_presets/blend_alpha.txt
@@ -1,0 +1,3 @@
+# Micro preset for alpha blending with half weight
+overlay op=replace fg=0xff0000
+blend op=alpha fg=0x00ff00 alpha=128

--- a/tests/data/micro_presets/overlay_blendslide.txt
+++ b/tests/data/micro_presets/overlay_blendslide.txt
@@ -1,0 +1,2 @@
+# Micro preset applying blend-slide overlay between red and blue
+overlay op=blendslide bg=0xff0000 fg=0x0000ff slide=64

--- a/tests/data/micro_presets/swizzle_bgr.txt
+++ b/tests/data/micro_presets/swizzle_bgr.txt
@@ -1,0 +1,2 @@
+# Swizzle only: reorder channels to BGR
+swizzle mode=bgr

--- a/tests/golden/micro_blend_md5.txt
+++ b/tests/golden/micro_blend_md5.txt
@@ -1,0 +1,5 @@
+# name md5
+blend_additive 2c9accb89e77e2dd59f57ca974ef36b6
+blend_alpha 560c7034dfcc449a6365b82bcf9379eb
+overlay_blendslide 9189499d7106a30a1e58ea2c6a5ff789
+swizzle_bgr fa44900dc5b28feed9598e38288d2f31

--- a/tools/update_goldens.sh
+++ b/tools/update_goldens.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BUILD_DIR=${BUILD_DIR:-build}
+
+if [ ! -d "${BUILD_DIR}" ]; then
+  echo "[update_goldens] build directory '${BUILD_DIR}' does not exist" >&2
+  echo "Run CMake configure step first (e.g., cmake -S . -B ${BUILD_DIR})" >&2
+  exit 1
+fi
+
+cmake --build "${BUILD_DIR}" --target core_effects_tests
+UPDATE_GOLDENS=1 "${BUILD_DIR}/tests/core_effects_tests"


### PR DESCRIPTION
## Summary
- implement BlendOp dispatch with AVS-compatible math and expose blend/overlay/swizzle effects
- add micro preset parser plus golden MD5 fixtures covering blend and swizzle behaviour
- document compatibility details and provide a helper script for updating golden hashes

## Testing
- cmake --build build --target core_effects_tests
- ctest --output-on-failure -R core_effects_tests


------
https://chatgpt.com/codex/tasks/task_e_68f0855ddc14832c9721095b1804e1da