### PR TITLE
Fix micro preset parser handling of hash-prefixed hex values

### DIFF
--- a/libs/avs/effects/src/micro_preset_parser.cpp
+++ b/libs/avs/effects/src/micro_preset_parser.cpp
@@ -166,9 +166,42 @@ MicroPreset parseMicroPreset(std::string_view text) {
     if (!line.empty() && line.back() == '\r') {
       line.pop_back();
     }
-    const auto commentPos = line.find('#');
-    if (commentPos != std::string::npos) {
-      line.erase(commentPos);
+    bool inQuote = false;
+    char quoteChar = '\0';
+    for (std::size_t i = 0; i < line.size(); ++i) {
+      const char ch = line[i];
+      if (inQuote) {
+        if (ch == quoteChar) {
+          inQuote = false;
+        }
+        continue;
+      }
+      if (ch == '"' || ch == 39) {
+        inQuote = true;
+        quoteChar = ch;
+        continue;
+      }
+      if (ch == '#') {
+        std::size_t pos = i;
+        while (pos > 0) {
+          const unsigned char prev = static_cast<unsigned char>(line[pos - 1]);
+          if (!std::isspace(prev)) {
+            break;
+          }
+          --pos;
+        }
+        bool treatAsComment = true;
+        if (pos > 0) {
+          const unsigned char prev = static_cast<unsigned char>(line[pos - 1]);
+          if (prev == '=') {
+            treatAsComment = false;
+          }
+        }
+        if (treatAsComment) {
+          line.erase(i);
+          break;
+        }
+      }
     }
     const std::string trimmed = trimCopy(line);
     if (trimmed.empty()) {

--- a/tests/core/test_blend_ops.cpp
+++ b/tests/core/test_blend_ops.cpp
@@ -196,6 +196,17 @@ CHECKBOX extra
   ASSERT_FALSE(parsed.warnings.empty());
 }
 
+TEST(MicroPresetParser, KeepsHashPrefixedHexValues) {
+  const char* text = R"(blend fg=#00ff00 bg=#ff0000 # trailing comment
+)";
+  auto parsed = avs::effects::parseMicroPreset(text);
+  ASSERT_EQ(parsed.commands.size(), 1u);
+  const auto& cmd = parsed.commands.front();
+  EXPECT_EQ(cmd.effectKey, "blend");
+  EXPECT_EQ(cmd.params.getInt("fg", 0), 0x00ff00);
+  EXPECT_EQ(cmd.params.getInt("bg", 0), 0xff0000);
+}
+
 class BlendEffectsTest : public ::testing::Test {
  protected:
   BlendEffectsTest() { avs::effects::registerCoreEffects(registry_); }


### PR DESCRIPTION
## Summary
- refine micro preset parser comment stripping so hash-prefixed values are preserved
- add a regression test covering hash-based colour assignments

## Testing
- bash ./run_build.sh *(fails: PortAudio not found in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f09be5638c832caf15ba6b7fe51b15