### PR TITLE
fix: ensure analyzer updates when damping is disabled

### DIFF
--- a/src/audio/analyzer.cpp
+++ b/src/audio/analyzer.cpp
@@ -18,7 +18,7 @@ constexpr std::size_t kEnergyWindow = 43;  // ~1s at 1024 hop / 44100 Hz
 constexpr float kMinEnergy = 1e-6f;
 constexpr float kMaxConfidence = 4.0f;
 constexpr float kDampingFactor = 0.6f;
-constexpr float kNoDampingFactor = 1.0f;
+constexpr float kNoDampingFactor = 0.0f;
 
 std::vector<float> makeHannWindow(std::size_t size) {
   constexpr double pi = 3.14159265358979323846;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -26,6 +26,12 @@ target_link_libraries(audio_device_negotiation_tests PRIVATE avs-audio GTest::gt
 target_compile_options(audio_device_negotiation_tests PRIVATE -Wall -Wextra -Werror)
 add_test(NAME audio_device_negotiation_tests COMMAND audio_device_negotiation_tests)
 
+add_executable(audio_analyzer_tests audio/test_analyzer.cpp)
+target_link_libraries(audio_analyzer_tests PRIVATE avs-platform avs-audio GTest::gtest_main)
+target_compile_options(audio_analyzer_tests PRIVATE -Wall -Wextra -Werror)
+target_include_directories(audio_analyzer_tests PRIVATE ${CMAKE_SOURCE_DIR}/src)
+add_test(NAME audio_analyzer_tests COMMAND audio_analyzer_tests)
+
 add_executable(deterministic_render_test deterministic_render_test.cpp)
 target_link_libraries(deterministic_render_test PRIVATE GTest::gtest_main)
 target_compile_options(deterministic_render_test PRIVATE -Wall -Wextra -Werror)

--- a/tests/audio/test_analyzer.cpp
+++ b/tests/audio/test_analyzer.cpp
@@ -1,0 +1,31 @@
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cmath>
+#include <vector>
+
+#include "audio/analyzer.h"
+
+namespace {
+
+using avs::audio::Analysis;
+using avs::audio::Analyzer;
+
+TEST(AudioAnalyzerTest, ProcessesNewSamplesWhenDampingDisabled) {
+  Analyzer analyzer{44100, 1};
+  analyzer.setDampingEnabled(false);
+
+  std::vector<float> frame(Analysis::kFftSize * 1u, 0.0f);
+  analyzer.process(frame.data(), Analysis::kFftSize);
+
+  std::fill(frame.begin(), frame.end(), 1.0f);
+  const Analysis& analysis = analyzer.process(frame.data(), Analysis::kFftSize);
+
+  const bool hasNonZeroWaveform = std::any_of(analysis.waveform.begin(), analysis.waveform.end(),
+                                              [](float value) { return std::abs(value) > 1e-6f; });
+
+  EXPECT_TRUE(hasNonZeroWaveform);
+  EXPECT_GT(analysis.spectrum.front(), 0.0f);
+}
+
+}  // namespace


### PR DESCRIPTION
## Summary
- set the no-damping constant to zero so the analyzer continues ingesting new frames when damping is disabled
- add an audio analyzer unit test that ensures undamped processing updates the waveform and spectrum
- register the new test target with CMake so it builds alongside the other audio tests

## Testing
- ctest --test-dir build

------
https://chatgpt.com/codex/tasks/task_e_68f09ac95510832c9b9d98e2ddc8f6ca