### PR TITLE
chore: improve unimplemented effects detection

### DIFF
--- a/tools/get_unimplemented_effects.sh
+++ b/tools/get_unimplemented_effects.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export REPO_ROOT="$(git rev-parse --show-toplevel)"
+
+python3 <<'PY'
+import os
+import pathlib
+import re
+
+repo = pathlib.Path(os.environ["REPO_ROOT"])
+registry_path = repo / "libs/avs-core/src/registry.cpp"
+source_paths = [
+    repo / "libs/avs-core/src/effects_render.cpp",
+    repo / "libs/avs-core/src/effects_trans.cpp",
+    repo / "libs/avs-core/src/effects_misc.cpp",
+]
+header_paths = [
+    repo / "libs/avs-core/include/avs/effects_render.hpp",
+    repo / "libs/avs-core/include/avs/effects_trans.hpp",
+    repo / "libs/avs-core/include/avs/effects_misc.hpp",
+]
+
+class_to_name: dict[str, str] = {}
+for header in header_paths:
+    if not header.is_file():
+        continue
+    current_class = None
+    for line in header.read_text().splitlines():
+        class_match = re.match(r"\s*class\s+(\w+)", line)
+        if class_match:
+            current_class = class_match.group(1)
+        name_match = re.search(r'return\s+"([^"]+)"', line)
+        if current_class and name_match:
+            class_to_name[current_class] = name_match.group(1)
+        if current_class and line.strip().startswith('};'):
+            current_class = None
+
+registered: dict[str, str] = {}
+if registry_path.is_file():
+    for line in registry_path.read_text().splitlines():
+        m = re.search(r'REG\("([^"]+)",\s*([A-Za-z0-9_]+),', line)
+        if m:
+            effect_id, cls = m.group(1), m.group(2)
+            registered[cls] = effect_id
+
+keywords = ("stub", "placeholder", "todo", "unimplemented")
+
+source_text: dict[str, str] = {str(path): path.read_text() for path in source_paths if path.is_file()}
+
+class_to_stub: dict[str, bool] = {}
+
+def remove_comments(code: str) -> str:
+    code = re.sub(r'//.*', '', code)
+    code = re.sub(r'/\*.*?\*/', '', code, flags=re.S)
+    return code
+
+def preceding_comment(text: str, idx: int) -> str:
+    i = idx
+    lines: list[str] = []
+    while i > 0:
+        j = text.rfind('\n', 0, i)
+        if j == -1:
+            segment = text[:i]
+            if segment.strip().startswith('//'):
+                lines.append(segment.strip())
+            break
+        segment = text[j + 1:i].strip()
+        if not segment:
+            break
+        if segment.startswith('//'):
+            lines.append(segment)
+            i = j
+            continue
+        if segment.endswith('*/'):
+            k = text.rfind('/*', 0, j)
+            if k == -1:
+                break
+            block = text[k:j].splitlines()
+            lines.extend(s.strip() for s in block if s.strip())
+            i = k
+            continue
+        break
+    return '\n'.join(reversed(lines))
+
+for path_str, text in source_text.items():
+    for match in re.finditer(r'void\s+([A-Za-z0-9_]+)::process\s*\([^)]*\)\s*\{', text):
+        cls = match.group(1)
+        start = match.end()
+        depth = 1
+        i = start
+        while i < len(text) and depth > 0:
+            if text[i] == '{':
+                depth += 1
+            elif text[i] == '}':
+                depth -= 1
+            i += 1
+        body = text[start:i-1]
+        comment_text = preceding_comment(text, match.start())
+        body_lower = body.lower()
+        comment_lower = comment_text.lower()
+
+        is_stub = False
+        if any(k in body_lower for k in keywords) or any(k in comment_lower for k in keywords):
+            is_stub = True
+        else:
+            simplified = remove_comments(body)
+            simplified = simplified.replace('{', '').replace('}', '')
+            simplified_no_ws = re.sub(r'\s+', '', simplified)
+            trivial_patterns = [
+                r'\(void\)ctx;',
+                r'\(void\)dst;',
+                r'return;',
+                r'MovementEffect\(\)\.process\(ctx,dst\);',
+            ]
+            tmp = simplified_no_ws
+            for pat in trivial_patterns:
+                tmp = re.sub(pat, '', tmp)
+            if not tmp:
+                is_stub = True
+
+        class_to_stub[cls] = is_stub
+
+unimplemented = []
+for cls, effect_id in registered.items():
+    if class_to_stub.get(cls):
+        name = class_to_name.get(cls, cls)
+        unimplemented.append((name, effect_id))
+
+unimplemented.sort()
+for name, effect_id in unimplemented:
+    print(f"{effect_id}: {name}")
+PY


### PR DESCRIPTION
## Summary
- add a Python-backed implementation for tools/get_unimplemented_effects.sh
- scan the registered effect classes and flag those whose process methods are still stubs
- emit the friendly effect name with its registry identifier for easier tracking

## Testing
- ./tools/get_unimplemented_effects.sh

------
https://chatgpt.com/codex/tasks/task_e_68f09ff70f90832cb8c8f967371098c6