### PR TITLE
feat: add legacy AVS effect stubs

### DIFF
--- a/docs/compat/manifest.yaml
+++ b/docs/compat/manifest.yaml
@@ -93,3 +93,97 @@ goldens:
   micro_blend_md5:
     file: tests/golden/micro_blend_md5.txt
     update_command: ./tools/update_goldens.sh
+stubs:
+  - name: Channel Shift
+    status: stub
+    source: vis_avs/rlib.cpp (R_ChannelShift)
+  - name: Color Reduction
+    status: stub
+    source: vis_avs/rlib.cpp (R_ColorReduction)
+  - name: Holden04: Video Delay
+    status: stub
+    source: vis_avs/rlib.cpp (R_VideoDelay)
+  - name: Holden05: Multi Delay
+    status: stub
+    source: vis_avs/rlib.cpp (R_MultiDelay)
+  - name: Misc / Comment
+    status: stub
+    source: vis_avs/r_comment.cpp (R_Comment)
+  - name: Misc / Custom BPM
+    status: stub
+    source: vis_avs/r_bpm.cpp (R_Bpm)
+  - name: Misc / Set render mode
+    status: stub
+    source: vis_avs/r_linemode.cpp (R_LineMode)
+  - name: Multiplier
+    status: stub
+    source: vis_avs/rlib.cpp (R_Multiplier)
+  - name: Render / AVI
+    status: stub
+    source: vis_avs/r_avi.cpp (R_AVI)
+  - name: Render / Bass Spin
+    status: stub
+    source: vis_avs/r_bspin.cpp (R_BSpin)
+  - name: Render / Dot Fountain
+    status: stub
+    source: vis_avs/r_dotfnt.cpp (R_DotFountain)
+  - name: Render / Dot Plane
+    status: stub
+    source: vis_avs/r_dotpln.cpp (R_DotPlane)
+  - name: Render / Moving Particle
+    status: stub
+    source: vis_avs/r_parts.cpp (R_Parts)
+  - name: Render / Oscilloscope Star
+    status: stub
+    source: vis_avs/r_oscstar.cpp (R_OscStars)
+  - name: Render / Ring
+    status: stub
+    source: vis_avs/r_oscring.cpp (R_OscRings)
+  - name: Render / Rotating Stars
+    status: stub
+    source: vis_avs/r_rotstar.cpp (R_RotStar)
+  - name: Render / Simple
+    status: stub
+    source: vis_avs/r_simple.cpp (R_SimpleSpectrum)
+  - name: Render / SVP Loader
+    status: stub
+    source: vis_avs/r_svp.cpp (R_SVP)
+  - name: Render / Timescope
+    status: stub
+    source: vis_avs/r_timescope.cpp (R_Timescope)
+  - name: Trans / Blitter Feedback
+    status: stub
+    source: vis_avs/r_blit.cpp (R_BlitterFB)
+  - name: Trans / Blur
+    status: stub
+    source: vis_avs/r_blur.cpp (R_Blur)
+  - name: Trans / Brightness
+    status: stub
+    source: vis_avs/r_bright.cpp (R_Brightness)
+  - name: Trans / Color Clip
+    status: stub
+    source: vis_avs/r_colorreplace.cpp (R_ContrastEnhance)
+  - name: Trans / Color Modifier
+    status: stub
+    source: vis_avs/r_dcolormod.cpp (R_DColorMod)
+  - name: Trans / Colorfade
+    status: stub
+    source: vis_avs/r_colorfade.cpp (R_ColorFade)
+  - name: Trans / Mosaic
+    status: stub
+    source: vis_avs/r_mosaic.cpp (R_Mosaic)
+  - name: Trans / Roto Blitter
+    status: stub
+    source: vis_avs/r_rotblit.cpp (R_RotBlit)
+  - name: Trans / Scatter
+    status: stub
+    source: vis_avs/r_scat.cpp (R_Scat)
+  - name: Trans / Unique tone
+    status: stub
+    source: vis_avs/r_onetone.cpp (R_Onetone)
+  - name: Trans / Water
+    status: stub
+    source: vis_avs/r_water.cpp (R_Water)
+  - name: Trans / Water Bump
+    status: stub
+    source: vis_avs/r_waterbump.cpp (R_WaterBump)

--- a/docs/effects/stubs/channel_shift.md
+++ b/docs/effects/stubs/channel_shift.md
@@ -1,0 +1,3 @@
+# Channel Shift
+
+This is a stub for compatibility with legacy AVS presets. No functional rendering is implemented yet.

--- a/docs/effects/stubs/color_reduction.md
+++ b/docs/effects/stubs/color_reduction.md
@@ -1,0 +1,3 @@
+# Color Reduction
+
+This is a stub for compatibility with legacy AVS presets. No functional rendering is implemented yet.

--- a/docs/effects/stubs/holden04_video_delay.md
+++ b/docs/effects/stubs/holden04_video_delay.md
@@ -1,0 +1,3 @@
+# Holden04: Video Delay
+
+This is a stub for compatibility with legacy AVS presets. No functional rendering is implemented yet.

--- a/docs/effects/stubs/holden05_multi_delay.md
+++ b/docs/effects/stubs/holden05_multi_delay.md
@@ -1,0 +1,3 @@
+# Holden05: Multi Delay
+
+This is a stub for compatibility with legacy AVS presets. No functional rendering is implemented yet.

--- a/docs/effects/stubs/misc_comment.md
+++ b/docs/effects/stubs/misc_comment.md
@@ -1,0 +1,3 @@
+# Misc / Comment
+
+This is a stub for compatibility with legacy AVS presets. No functional rendering is implemented yet.

--- a/docs/effects/stubs/misc_custom_bpm.md
+++ b/docs/effects/stubs/misc_custom_bpm.md
@@ -1,0 +1,3 @@
+# Misc / Custom BPM
+
+This is a stub for compatibility with legacy AVS presets. No functional rendering is implemented yet.

--- a/docs/effects/stubs/misc_set_render_mode.md
+++ b/docs/effects/stubs/misc_set_render_mode.md
@@ -1,0 +1,3 @@
+# Misc / Set render mode
+
+This is a stub for compatibility with legacy AVS presets. No functional rendering is implemented yet.

--- a/docs/effects/stubs/multiplier.md
+++ b/docs/effects/stubs/multiplier.md
@@ -1,0 +1,3 @@
+# Multiplier
+
+This is a stub for compatibility with legacy AVS presets. No functional rendering is implemented yet.

--- a/docs/effects/stubs/render_avi.md
+++ b/docs/effects/stubs/render_avi.md
@@ -1,0 +1,3 @@
+# Render / AVI
+
+This is a stub for compatibility with legacy AVS presets. No functional rendering is implemented yet.

--- a/docs/effects/stubs/render_bass_spin.md
+++ b/docs/effects/stubs/render_bass_spin.md
@@ -1,0 +1,3 @@
+# Render / Bass Spin
+
+This is a stub for compatibility with legacy AVS presets. No functional rendering is implemented yet.

--- a/docs/effects/stubs/render_dot_fountain.md
+++ b/docs/effects/stubs/render_dot_fountain.md
@@ -1,0 +1,3 @@
+# Render / Dot Fountain
+
+This is a stub for compatibility with legacy AVS presets. No functional rendering is implemented yet.

--- a/docs/effects/stubs/render_dot_plane.md
+++ b/docs/effects/stubs/render_dot_plane.md
@@ -1,0 +1,3 @@
+# Render / Dot Plane
+
+This is a stub for compatibility with legacy AVS presets. No functional rendering is implemented yet.

--- a/docs/effects/stubs/render_moving_particle.md
+++ b/docs/effects/stubs/render_moving_particle.md
@@ -1,0 +1,3 @@
+# Render / Moving Particle
+
+This is a stub for compatibility with legacy AVS presets. No functional rendering is implemented yet.

--- a/docs/effects/stubs/render_oscilloscope_star.md
+++ b/docs/effects/stubs/render_oscilloscope_star.md
@@ -1,0 +1,3 @@
+# Render / Oscilloscope Star
+
+This is a stub for compatibility with legacy AVS presets. No functional rendering is implemented yet.

--- a/docs/effects/stubs/render_ring.md
+++ b/docs/effects/stubs/render_ring.md
@@ -1,0 +1,3 @@
+# Render / Ring
+
+This is a stub for compatibility with legacy AVS presets. No functional rendering is implemented yet.

--- a/docs/effects/stubs/render_rotating_stars.md
+++ b/docs/effects/stubs/render_rotating_stars.md
@@ -1,0 +1,3 @@
+# Render / Rotating Stars
+
+This is a stub for compatibility with legacy AVS presets. No functional rendering is implemented yet.

--- a/docs/effects/stubs/render_simple.md
+++ b/docs/effects/stubs/render_simple.md
@@ -1,0 +1,3 @@
+# Render / Simple
+
+This is a stub for compatibility with legacy AVS presets. No functional rendering is implemented yet.

--- a/docs/effects/stubs/render_svp_loader.md
+++ b/docs/effects/stubs/render_svp_loader.md
@@ -1,0 +1,3 @@
+# Render / SVP Loader
+
+This is a stub for compatibility with legacy AVS presets. No functional rendering is implemented yet.

--- a/docs/effects/stubs/render_timescope.md
+++ b/docs/effects/stubs/render_timescope.md
@@ -1,0 +1,3 @@
+# Render / Timescope
+
+This is a stub for compatibility with legacy AVS presets. No functional rendering is implemented yet.

--- a/docs/effects/stubs/trans_blitter_feedback.md
+++ b/docs/effects/stubs/trans_blitter_feedback.md
@@ -1,0 +1,3 @@
+# Trans / Blitter Feedback
+
+This is a stub for compatibility with legacy AVS presets. No functional rendering is implemented yet.

--- a/docs/effects/stubs/trans_blur.md
+++ b/docs/effects/stubs/trans_blur.md
@@ -1,0 +1,3 @@
+# Trans / Blur
+
+This is a stub for compatibility with legacy AVS presets. No functional rendering is implemented yet.

--- a/docs/effects/stubs/trans_brightness.md
+++ b/docs/effects/stubs/trans_brightness.md
@@ -1,0 +1,3 @@
+# Trans / Brightness
+
+This is a stub for compatibility with legacy AVS presets. No functional rendering is implemented yet.

--- a/docs/effects/stubs/trans_color_clip.md
+++ b/docs/effects/stubs/trans_color_clip.md
@@ -1,0 +1,3 @@
+# Trans / Color Clip
+
+This is a stub for compatibility with legacy AVS presets. No functional rendering is implemented yet.

--- a/docs/effects/stubs/trans_color_modifier.md
+++ b/docs/effects/stubs/trans_color_modifier.md
@@ -1,0 +1,3 @@
+# Trans / Color Modifier
+
+This is a stub for compatibility with legacy AVS presets. No functional rendering is implemented yet.

--- a/docs/effects/stubs/trans_colorfade.md
+++ b/docs/effects/stubs/trans_colorfade.md
@@ -1,0 +1,3 @@
+# Trans / Colorfade
+
+This is a stub for compatibility with legacy AVS presets. No functional rendering is implemented yet.

--- a/docs/effects/stubs/trans_mosaic.md
+++ b/docs/effects/stubs/trans_mosaic.md
@@ -1,0 +1,3 @@
+# Trans / Mosaic
+
+This is a stub for compatibility with legacy AVS presets. No functional rendering is implemented yet.

--- a/docs/effects/stubs/trans_roto_blitter.md
+++ b/docs/effects/stubs/trans_roto_blitter.md
@@ -1,0 +1,3 @@
+# Trans / Roto Blitter
+
+This is a stub for compatibility with legacy AVS presets. No functional rendering is implemented yet.

--- a/docs/effects/stubs/trans_scatter.md
+++ b/docs/effects/stubs/trans_scatter.md
@@ -1,0 +1,3 @@
+# Trans / Scatter
+
+This is a stub for compatibility with legacy AVS presets. No functional rendering is implemented yet.

--- a/docs/effects/stubs/trans_unique_tone.md
+++ b/docs/effects/stubs/trans_unique_tone.md
@@ -1,0 +1,3 @@
+# Trans / Unique tone
+
+This is a stub for compatibility with legacy AVS presets. No functional rendering is implemented yet.

--- a/docs/effects/stubs/trans_water.md
+++ b/docs/effects/stubs/trans_water.md
@@ -1,0 +1,3 @@
+# Trans / Water
+
+This is a stub for compatibility with legacy AVS presets. No functional rendering is implemented yet.

--- a/docs/effects/stubs/trans_water_bump.md
+++ b/docs/effects/stubs/trans_water_bump.md
@@ -1,0 +1,3 @@
+# Trans / Water Bump
+
+This is a stub for compatibility with legacy AVS presets. No functional rendering is implemented yet.

--- a/libs/avs/effects/CMakeLists.txt
+++ b/libs/avs/effects/CMakeLists.txt
@@ -1,3 +1,38 @@
+set(AVS_EFFECT_STUB_SOURCES
+  ${CMAKE_SOURCE_DIR}/src/effects/effect.cpp
+  ${CMAKE_SOURCE_DIR}/src/effects/stubs/effect_channel_shift.cpp
+  ${CMAKE_SOURCE_DIR}/src/effects/stubs/effect_color_reduction.cpp
+  ${CMAKE_SOURCE_DIR}/src/effects/stubs/effect_holden04_video_delay.cpp
+  ${CMAKE_SOURCE_DIR}/src/effects/stubs/effect_holden05_multi_delay.cpp
+  ${CMAKE_SOURCE_DIR}/src/effects/stubs/effect_misc_comment.cpp
+  ${CMAKE_SOURCE_DIR}/src/effects/stubs/effect_misc_custom_bpm.cpp
+  ${CMAKE_SOURCE_DIR}/src/effects/stubs/effect_misc_set_render_mode.cpp
+  ${CMAKE_SOURCE_DIR}/src/effects/stubs/effect_multiplier.cpp
+  ${CMAKE_SOURCE_DIR}/src/effects/stubs/effect_render_avi.cpp
+  ${CMAKE_SOURCE_DIR}/src/effects/stubs/effect_render_bass_spin.cpp
+  ${CMAKE_SOURCE_DIR}/src/effects/stubs/effect_render_dot_fountain.cpp
+  ${CMAKE_SOURCE_DIR}/src/effects/stubs/effect_render_dot_plane.cpp
+  ${CMAKE_SOURCE_DIR}/src/effects/stubs/effect_render_moving_particle.cpp
+  ${CMAKE_SOURCE_DIR}/src/effects/stubs/effect_render_oscilloscope_star.cpp
+  ${CMAKE_SOURCE_DIR}/src/effects/stubs/effect_render_ring.cpp
+  ${CMAKE_SOURCE_DIR}/src/effects/stubs/effect_render_rotating_stars.cpp
+  ${CMAKE_SOURCE_DIR}/src/effects/stubs/effect_render_simple.cpp
+  ${CMAKE_SOURCE_DIR}/src/effects/stubs/effect_render_svp_loader.cpp
+  ${CMAKE_SOURCE_DIR}/src/effects/stubs/effect_render_timescope.cpp
+  ${CMAKE_SOURCE_DIR}/src/effects/stubs/effect_trans_blitter_feedback.cpp
+  ${CMAKE_SOURCE_DIR}/src/effects/stubs/effect_trans_blur.cpp
+  ${CMAKE_SOURCE_DIR}/src/effects/stubs/effect_trans_brightness.cpp
+  ${CMAKE_SOURCE_DIR}/src/effects/stubs/effect_trans_color_clip.cpp
+  ${CMAKE_SOURCE_DIR}/src/effects/stubs/effect_trans_color_modifier.cpp
+  ${CMAKE_SOURCE_DIR}/src/effects/stubs/effect_trans_colorfade.cpp
+  ${CMAKE_SOURCE_DIR}/src/effects/stubs/effect_trans_mosaic.cpp
+  ${CMAKE_SOURCE_DIR}/src/effects/stubs/effect_trans_roto_blitter.cpp
+  ${CMAKE_SOURCE_DIR}/src/effects/stubs/effect_trans_scatter.cpp
+  ${CMAKE_SOURCE_DIR}/src/effects/stubs/effect_trans_unique_tone.cpp
+  ${CMAKE_SOURCE_DIR}/src/effects/stubs/effect_trans_water.cpp
+  ${CMAKE_SOURCE_DIR}/src/effects/stubs/effect_trans_water_bump.cpp
+  ${CMAKE_SOURCE_DIR}/src/runtime/parser.cpp)
+
 add_library(avs-effects-core
   src/Blend.cpp
   src/Clear.cpp
@@ -18,7 +53,8 @@ add_library(avs-effects-core
   src/effects/primitive_rrect.cpp
   src/effects/primitive_solid.cpp
   src/effects/primitive_tri.cpp
-  src/text/text_renderer.cpp)
+  src/text/text_renderer.cpp
+  ${AVS_EFFECT_STUB_SOURCES})
 
 
 target_link_libraries(avs-effects-core PUBLIC avs-core-runtime avs-runtime)

--- a/libs/avs/effects/src/RegisterEffects.cpp
+++ b/libs/avs/effects/src/RegisterEffects.cpp
@@ -11,6 +11,37 @@
 #include "avs/effects/TransformAffine.hpp"
 #include "avs/effects/Zoom.hpp"
 #include "effects/effect_scripted.h"
+#include "effects/stubs/effect_channel_shift.h"
+#include "effects/stubs/effect_color_reduction.h"
+#include "effects/stubs/effect_holden04_video_delay.h"
+#include "effects/stubs/effect_holden05_multi_delay.h"
+#include "effects/stubs/effect_misc_comment.h"
+#include "effects/stubs/effect_misc_custom_bpm.h"
+#include "effects/stubs/effect_misc_set_render_mode.h"
+#include "effects/stubs/effect_multiplier.h"
+#include "effects/stubs/effect_render_avi.h"
+#include "effects/stubs/effect_render_bass_spin.h"
+#include "effects/stubs/effect_render_dot_fountain.h"
+#include "effects/stubs/effect_render_dot_plane.h"
+#include "effects/stubs/effect_render_moving_particle.h"
+#include "effects/stubs/effect_render_oscilloscope_star.h"
+#include "effects/stubs/effect_render_ring.h"
+#include "effects/stubs/effect_render_rotating_stars.h"
+#include "effects/stubs/effect_render_simple.h"
+#include "effects/stubs/effect_render_svp_loader.h"
+#include "effects/stubs/effect_render_timescope.h"
+#include "effects/stubs/effect_trans_blitter_feedback.h"
+#include "effects/stubs/effect_trans_blur.h"
+#include "effects/stubs/effect_trans_brightness.h"
+#include "effects/stubs/effect_trans_color_clip.h"
+#include "effects/stubs/effect_trans_color_modifier.h"
+#include "effects/stubs/effect_trans_colorfade.h"
+#include "effects/stubs/effect_trans_mosaic.h"
+#include "effects/stubs/effect_trans_roto_blitter.h"
+#include "effects/stubs/effect_trans_scatter.h"
+#include "effects/stubs/effect_trans_unique_tone.h"
+#include "effects/stubs/effect_trans_water.h"
+#include "effects/stubs/effect_trans_water_bump.h"
 
 namespace avs::effects {
 
@@ -38,6 +69,69 @@ void registerCoreEffects(avs::core::EffectRegistry& registry) {
   registry.registerFactory("rrect", []() { return std::make_unique<PrimitiveRoundedRect>(); });
   registry.registerFactory("roundedrect", []() { return std::make_unique<PrimitiveRoundedRect>(); });
   registry.registerFactory("text", []() { return std::make_unique<Text>(); });
+
+  registry.registerFactory("Channel Shift", []() { return std::make_unique<Effect_ChannelShift>(); });
+  registry.registerFactory("channel shift", []() { return std::make_unique<Effect_ChannelShift>(); });
+  registry.registerFactory("Color Reduction", []() { return std::make_unique<Effect_ColorReduction>(); });
+  registry.registerFactory("color reduction", []() { return std::make_unique<Effect_ColorReduction>(); });
+  registry.registerFactory("Holden04: Video Delay", []() { return std::make_unique<Effect_Holden04VideoDelay>(); });
+  registry.registerFactory("holden04: video delay", []() { return std::make_unique<Effect_Holden04VideoDelay>(); });
+  registry.registerFactory("Holden05: Multi Delay", []() { return std::make_unique<Effect_Holden05MultiDelay>(); });
+  registry.registerFactory("holden05: multi delay", []() { return std::make_unique<Effect_Holden05MultiDelay>(); });
+  registry.registerFactory("Misc / Comment", []() { return std::make_unique<Effect_MiscComment>(); });
+  registry.registerFactory("misc / comment", []() { return std::make_unique<Effect_MiscComment>(); });
+  registry.registerFactory("Misc / Custom BPM", []() { return std::make_unique<Effect_MiscCustomBpm>(); });
+  registry.registerFactory("misc / custom bpm", []() { return std::make_unique<Effect_MiscCustomBpm>(); });
+  registry.registerFactory("Misc / Set render mode", []() { return std::make_unique<Effect_MiscSetRenderMode>(); });
+  registry.registerFactory("misc / set render mode", []() { return std::make_unique<Effect_MiscSetRenderMode>(); });
+  registry.registerFactory("Multiplier", []() { return std::make_unique<Effect_Multiplier>(); });
+  registry.registerFactory("multiplier", []() { return std::make_unique<Effect_Multiplier>(); });
+  registry.registerFactory("Render / AVI", []() { return std::make_unique<Effect_RenderAvi>(); });
+  registry.registerFactory("render / avi", []() { return std::make_unique<Effect_RenderAvi>(); });
+  registry.registerFactory("Render / Bass Spin", []() { return std::make_unique<Effect_RenderBassSpin>(); });
+  registry.registerFactory("render / bass spin", []() { return std::make_unique<Effect_RenderBassSpin>(); });
+  registry.registerFactory("Render / Dot Fountain", []() { return std::make_unique<Effect_RenderDotFountain>(); });
+  registry.registerFactory("render / dot fountain", []() { return std::make_unique<Effect_RenderDotFountain>(); });
+  registry.registerFactory("Render / Dot Plane", []() { return std::make_unique<Effect_RenderDotPlane>(); });
+  registry.registerFactory("render / dot plane", []() { return std::make_unique<Effect_RenderDotPlane>(); });
+  registry.registerFactory("Render / Moving Particle", []() { return std::make_unique<Effect_RenderMovingParticle>(); });
+  registry.registerFactory("render / moving particle", []() { return std::make_unique<Effect_RenderMovingParticle>(); });
+  registry.registerFactory("Render / Oscilloscope Star", []() { return std::make_unique<Effect_RenderOscilloscopeStar>(); });
+  registry.registerFactory("render / oscilloscope star", []() { return std::make_unique<Effect_RenderOscilloscopeStar>(); });
+  registry.registerFactory("Render / Ring", []() { return std::make_unique<Effect_RenderRing>(); });
+  registry.registerFactory("render / ring", []() { return std::make_unique<Effect_RenderRing>(); });
+  registry.registerFactory("Render / Rotating Stars", []() { return std::make_unique<Effect_RenderRotatingStars>(); });
+  registry.registerFactory("render / rotating stars", []() { return std::make_unique<Effect_RenderRotatingStars>(); });
+  registry.registerFactory("Render / Simple", []() { return std::make_unique<Effect_RenderSimple>(); });
+  registry.registerFactory("render / simple", []() { return std::make_unique<Effect_RenderSimple>(); });
+  registry.registerFactory("Render / SVP Loader", []() { return std::make_unique<Effect_RenderSvpLoader>(); });
+  registry.registerFactory("render / svp loader", []() { return std::make_unique<Effect_RenderSvpLoader>(); });
+  registry.registerFactory("Render / Timescope", []() { return std::make_unique<Effect_RenderTimescope>(); });
+  registry.registerFactory("render / timescope", []() { return std::make_unique<Effect_RenderTimescope>(); });
+  registry.registerFactory("Trans / Blitter Feedback", []() { return std::make_unique<Effect_TransBlitterFeedback>(); });
+  registry.registerFactory("trans / blitter feedback", []() { return std::make_unique<Effect_TransBlitterFeedback>(); });
+  registry.registerFactory("Trans / Blur", []() { return std::make_unique<Effect_TransBlur>(); });
+  registry.registerFactory("trans / blur", []() { return std::make_unique<Effect_TransBlur>(); });
+  registry.registerFactory("Trans / Brightness", []() { return std::make_unique<Effect_TransBrightness>(); });
+  registry.registerFactory("trans / brightness", []() { return std::make_unique<Effect_TransBrightness>(); });
+  registry.registerFactory("Trans / Color Clip", []() { return std::make_unique<Effect_TransColorClip>(); });
+  registry.registerFactory("trans / color clip", []() { return std::make_unique<Effect_TransColorClip>(); });
+  registry.registerFactory("Trans / Color Modifier", []() { return std::make_unique<Effect_TransColorModifier>(); });
+  registry.registerFactory("trans / color modifier", []() { return std::make_unique<Effect_TransColorModifier>(); });
+  registry.registerFactory("Trans / Colorfade", []() { return std::make_unique<Effect_TransColorfade>(); });
+  registry.registerFactory("trans / colorfade", []() { return std::make_unique<Effect_TransColorfade>(); });
+  registry.registerFactory("Trans / Mosaic", []() { return std::make_unique<Effect_TransMosaic>(); });
+  registry.registerFactory("trans / mosaic", []() { return std::make_unique<Effect_TransMosaic>(); });
+  registry.registerFactory("Trans / Roto Blitter", []() { return std::make_unique<Effect_TransRotoBlitter>(); });
+  registry.registerFactory("trans / roto blitter", []() { return std::make_unique<Effect_TransRotoBlitter>(); });
+  registry.registerFactory("Trans / Scatter", []() { return std::make_unique<Effect_TransScatter>(); });
+  registry.registerFactory("trans / scatter", []() { return std::make_unique<Effect_TransScatter>(); });
+  registry.registerFactory("Trans / Unique tone", []() { return std::make_unique<Effect_TransUniqueTone>(); });
+  registry.registerFactory("trans / unique tone", []() { return std::make_unique<Effect_TransUniqueTone>(); });
+  registry.registerFactory("Trans / Water", []() { return std::make_unique<Effect_TransWater>(); });
+  registry.registerFactory("trans / water", []() { return std::make_unique<Effect_TransWater>(); });
+  registry.registerFactory("Trans / Water Bump", []() { return std::make_unique<Effect_TransWaterBump>(); });
+  registry.registerFactory("trans / water bump", []() { return std::make_unique<Effect_TransWaterBump>(); });
 
 }
 

--- a/libs/avs/effects/src/micro_preset_parser.cpp
+++ b/libs/avs/effects/src/micro_preset_parser.cpp
@@ -8,6 +8,8 @@
 #include <string>
 #include <string_view>
 
+#include "runtime/parser.h"
+
 namespace {
 
 std::string trimCopy(std::string_view text) {
@@ -218,7 +220,7 @@ MicroPreset parseMicroPreset(std::string_view text) {
       continue;
     }
     MicroEffectCommand command;
-    command.effectKey = toLower(effectToken);
+    command.effectKey = avs::runtime::parser::normalizeEffectToken(effectToken);
     for (std::size_t i = 1; i < tokens.size(); ++i) {
       const std::string& token = tokens[i];
       const auto eqPos = token.find('=');

--- a/src/effects/effect.cpp
+++ b/src/effects/effect.cpp
@@ -1,0 +1,10 @@
+#include "effects/effect.h"
+
+#include <iostream>
+#include <utility>
+
+Effect::Effect(std::string displayName) : displayName_(std::move(displayName)) {
+  std::clog << "Loaded stub: " << displayName_ << " — behavior not implemented" << std::endl;
+}
+
+void Effect::setParams(const avs::core::ParamBlock& params) { params_ = params; }

--- a/src/effects/effect.h
+++ b/src/effects/effect.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <string>
+
+#include "avs/core/IEffect.hpp"
+#include "avs/core/ParamBlock.hpp"
+
+// Base class for compatibility stub effects originating from legacy AVS modules.
+class Effect : public avs::core::IEffect {
+ public:
+  explicit Effect(std::string displayName);
+  ~Effect() override = default;
+
+  void setParams(const avs::core::ParamBlock& params) override;
+
+ protected:
+  [[nodiscard]] const std::string& displayName() const noexcept { return displayName_; }
+  [[nodiscard]] const avs::core::ParamBlock& params() const noexcept { return params_; }
+
+ private:
+  std::string displayName_;
+  avs::core::ParamBlock params_;
+};

--- a/src/effects/stubs/effect_channel_shift.cpp
+++ b/src/effects/stubs/effect_channel_shift.cpp
@@ -1,0 +1,10 @@
+#include "effects/stubs/effect_channel_shift.h"
+
+
+Effect_ChannelShift::Effect_ChannelShift() : Effect("Channel Shift") {}
+
+bool Effect_ChannelShift::render(avs::core::RenderContext& context) {
+  (void)context;
+  // TODO: Implement per R_ChannelShift in rlib.cpp
+  return true;
+}

--- a/src/effects/stubs/effect_channel_shift.h
+++ b/src/effects/stubs/effect_channel_shift.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "effects/effect.h"
+
+class Effect_ChannelShift : public Effect {
+ public:
+  Effect_ChannelShift();
+  ~Effect_ChannelShift() override = default;
+
+  bool render(avs::core::RenderContext& context) override;
+};

--- a/src/effects/stubs/effect_color_reduction.cpp
+++ b/src/effects/stubs/effect_color_reduction.cpp
@@ -1,0 +1,10 @@
+#include "effects/stubs/effect_color_reduction.h"
+
+
+Effect_ColorReduction::Effect_ColorReduction() : Effect("Color Reduction") {}
+
+bool Effect_ColorReduction::render(avs::core::RenderContext& context) {
+  (void)context;
+  // TODO: Implement per R_ColorReduction in rlib.cpp
+  return true;
+}

--- a/src/effects/stubs/effect_color_reduction.h
+++ b/src/effects/stubs/effect_color_reduction.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "effects/effect.h"
+
+class Effect_ColorReduction : public Effect {
+ public:
+  Effect_ColorReduction();
+  ~Effect_ColorReduction() override = default;
+
+  bool render(avs::core::RenderContext& context) override;
+};

--- a/src/effects/stubs/effect_holden04_video_delay.cpp
+++ b/src/effects/stubs/effect_holden04_video_delay.cpp
@@ -1,0 +1,10 @@
+#include "effects/stubs/effect_holden04_video_delay.h"
+
+
+Effect_Holden04VideoDelay::Effect_Holden04VideoDelay() : Effect("Holden04: Video Delay") {}
+
+bool Effect_Holden04VideoDelay::render(avs::core::RenderContext& context) {
+  (void)context;
+  // TODO: Implement per R_VideoDelay in rlib.cpp
+  return true;
+}

--- a/src/effects/stubs/effect_holden04_video_delay.h
+++ b/src/effects/stubs/effect_holden04_video_delay.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "effects/effect.h"
+
+class Effect_Holden04VideoDelay : public Effect {
+ public:
+  Effect_Holden04VideoDelay();
+  ~Effect_Holden04VideoDelay() override = default;
+
+  bool render(avs::core::RenderContext& context) override;
+};

--- a/src/effects/stubs/effect_holden05_multi_delay.cpp
+++ b/src/effects/stubs/effect_holden05_multi_delay.cpp
@@ -1,0 +1,10 @@
+#include "effects/stubs/effect_holden05_multi_delay.h"
+
+
+Effect_Holden05MultiDelay::Effect_Holden05MultiDelay() : Effect("Holden05: Multi Delay") {}
+
+bool Effect_Holden05MultiDelay::render(avs::core::RenderContext& context) {
+  (void)context;
+  // TODO: Implement per R_MultiDelay in rlib.cpp
+  return true;
+}

--- a/src/effects/stubs/effect_holden05_multi_delay.h
+++ b/src/effects/stubs/effect_holden05_multi_delay.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "effects/effect.h"
+
+class Effect_Holden05MultiDelay : public Effect {
+ public:
+  Effect_Holden05MultiDelay();
+  ~Effect_Holden05MultiDelay() override = default;
+
+  bool render(avs::core::RenderContext& context) override;
+};

--- a/src/effects/stubs/effect_misc_comment.cpp
+++ b/src/effects/stubs/effect_misc_comment.cpp
@@ -1,0 +1,10 @@
+#include "effects/stubs/effect_misc_comment.h"
+
+
+Effect_MiscComment::Effect_MiscComment() : Effect("Misc / Comment") {}
+
+bool Effect_MiscComment::render(avs::core::RenderContext& context) {
+  (void)context;
+  // TODO: Implement per R_Comment in r_comment.cpp
+  return true;
+}

--- a/src/effects/stubs/effect_misc_comment.h
+++ b/src/effects/stubs/effect_misc_comment.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "effects/effect.h"
+
+class Effect_MiscComment : public Effect {
+ public:
+  Effect_MiscComment();
+  ~Effect_MiscComment() override = default;
+
+  bool render(avs::core::RenderContext& context) override;
+};

--- a/src/effects/stubs/effect_misc_custom_bpm.cpp
+++ b/src/effects/stubs/effect_misc_custom_bpm.cpp
@@ -1,0 +1,10 @@
+#include "effects/stubs/effect_misc_custom_bpm.h"
+
+
+Effect_MiscCustomBpm::Effect_MiscCustomBpm() : Effect("Misc / Custom BPM") {}
+
+bool Effect_MiscCustomBpm::render(avs::core::RenderContext& context) {
+  (void)context;
+  // TODO: Implement per R_Bpm in r_bpm.cpp
+  return true;
+}

--- a/src/effects/stubs/effect_misc_custom_bpm.h
+++ b/src/effects/stubs/effect_misc_custom_bpm.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "effects/effect.h"
+
+class Effect_MiscCustomBpm : public Effect {
+ public:
+  Effect_MiscCustomBpm();
+  ~Effect_MiscCustomBpm() override = default;
+
+  bool render(avs::core::RenderContext& context) override;
+};

--- a/src/effects/stubs/effect_misc_set_render_mode.cpp
+++ b/src/effects/stubs/effect_misc_set_render_mode.cpp
@@ -1,0 +1,10 @@
+#include "effects/stubs/effect_misc_set_render_mode.h"
+
+
+Effect_MiscSetRenderMode::Effect_MiscSetRenderMode() : Effect("Misc / Set render mode") {}
+
+bool Effect_MiscSetRenderMode::render(avs::core::RenderContext& context) {
+  (void)context;
+  // TODO: Implement per R_LineMode in r_linemode.cpp
+  return true;
+}

--- a/src/effects/stubs/effect_misc_set_render_mode.h
+++ b/src/effects/stubs/effect_misc_set_render_mode.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "effects/effect.h"
+
+class Effect_MiscSetRenderMode : public Effect {
+ public:
+  Effect_MiscSetRenderMode();
+  ~Effect_MiscSetRenderMode() override = default;
+
+  bool render(avs::core::RenderContext& context) override;
+};

--- a/src/effects/stubs/effect_multiplier.cpp
+++ b/src/effects/stubs/effect_multiplier.cpp
@@ -1,0 +1,10 @@
+#include "effects/stubs/effect_multiplier.h"
+
+
+Effect_Multiplier::Effect_Multiplier() : Effect("Multiplier") {}
+
+bool Effect_Multiplier::render(avs::core::RenderContext& context) {
+  (void)context;
+  // TODO: Implement per R_Multiplier in rlib.cpp
+  return true;
+}

--- a/src/effects/stubs/effect_multiplier.h
+++ b/src/effects/stubs/effect_multiplier.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "effects/effect.h"
+
+class Effect_Multiplier : public Effect {
+ public:
+  Effect_Multiplier();
+  ~Effect_Multiplier() override = default;
+
+  bool render(avs::core::RenderContext& context) override;
+};

--- a/src/effects/stubs/effect_render_avi.cpp
+++ b/src/effects/stubs/effect_render_avi.cpp
@@ -1,0 +1,10 @@
+#include "effects/stubs/effect_render_avi.h"
+
+
+Effect_RenderAvi::Effect_RenderAvi() : Effect("Render / AVI") {}
+
+bool Effect_RenderAvi::render(avs::core::RenderContext& context) {
+  (void)context;
+  // TODO: Implement per R_AVI in r_avi.cpp
+  return true;
+}

--- a/src/effects/stubs/effect_render_avi.h
+++ b/src/effects/stubs/effect_render_avi.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "effects/effect.h"
+
+class Effect_RenderAvi : public Effect {
+ public:
+  Effect_RenderAvi();
+  ~Effect_RenderAvi() override = default;
+
+  bool render(avs::core::RenderContext& context) override;
+};

--- a/src/effects/stubs/effect_render_bass_spin.cpp
+++ b/src/effects/stubs/effect_render_bass_spin.cpp
@@ -1,0 +1,10 @@
+#include "effects/stubs/effect_render_bass_spin.h"
+
+
+Effect_RenderBassSpin::Effect_RenderBassSpin() : Effect("Render / Bass Spin") {}
+
+bool Effect_RenderBassSpin::render(avs::core::RenderContext& context) {
+  (void)context;
+  // TODO: Implement per R_BSpin in r_bspin.cpp
+  return true;
+}

--- a/src/effects/stubs/effect_render_bass_spin.h
+++ b/src/effects/stubs/effect_render_bass_spin.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "effects/effect.h"
+
+class Effect_RenderBassSpin : public Effect {
+ public:
+  Effect_RenderBassSpin();
+  ~Effect_RenderBassSpin() override = default;
+
+  bool render(avs::core::RenderContext& context) override;
+};

--- a/src/effects/stubs/effect_render_dot_fountain.cpp
+++ b/src/effects/stubs/effect_render_dot_fountain.cpp
@@ -1,0 +1,10 @@
+#include "effects/stubs/effect_render_dot_fountain.h"
+
+
+Effect_RenderDotFountain::Effect_RenderDotFountain() : Effect("Render / Dot Fountain") {}
+
+bool Effect_RenderDotFountain::render(avs::core::RenderContext& context) {
+  (void)context;
+  // TODO: Implement per R_DotFountain in r_dotfnt.cpp
+  return true;
+}

--- a/src/effects/stubs/effect_render_dot_fountain.h
+++ b/src/effects/stubs/effect_render_dot_fountain.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "effects/effect.h"
+
+class Effect_RenderDotFountain : public Effect {
+ public:
+  Effect_RenderDotFountain();
+  ~Effect_RenderDotFountain() override = default;
+
+  bool render(avs::core::RenderContext& context) override;
+};

--- a/src/effects/stubs/effect_render_dot_plane.cpp
+++ b/src/effects/stubs/effect_render_dot_plane.cpp
@@ -1,0 +1,10 @@
+#include "effects/stubs/effect_render_dot_plane.h"
+
+
+Effect_RenderDotPlane::Effect_RenderDotPlane() : Effect("Render / Dot Plane") {}
+
+bool Effect_RenderDotPlane::render(avs::core::RenderContext& context) {
+  (void)context;
+  // TODO: Implement per R_DotPlane in r_dotpln.cpp
+  return true;
+}

--- a/src/effects/stubs/effect_render_dot_plane.h
+++ b/src/effects/stubs/effect_render_dot_plane.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "effects/effect.h"
+
+class Effect_RenderDotPlane : public Effect {
+ public:
+  Effect_RenderDotPlane();
+  ~Effect_RenderDotPlane() override = default;
+
+  bool render(avs::core::RenderContext& context) override;
+};

--- a/src/effects/stubs/effect_render_moving_particle.cpp
+++ b/src/effects/stubs/effect_render_moving_particle.cpp
@@ -1,0 +1,10 @@
+#include "effects/stubs/effect_render_moving_particle.h"
+
+
+Effect_RenderMovingParticle::Effect_RenderMovingParticle() : Effect("Render / Moving Particle") {}
+
+bool Effect_RenderMovingParticle::render(avs::core::RenderContext& context) {
+  (void)context;
+  // TODO: Implement per R_Parts in r_parts.cpp
+  return true;
+}

--- a/src/effects/stubs/effect_render_moving_particle.h
+++ b/src/effects/stubs/effect_render_moving_particle.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "effects/effect.h"
+
+class Effect_RenderMovingParticle : public Effect {
+ public:
+  Effect_RenderMovingParticle();
+  ~Effect_RenderMovingParticle() override = default;
+
+  bool render(avs::core::RenderContext& context) override;
+};

--- a/src/effects/stubs/effect_render_oscilloscope_star.cpp
+++ b/src/effects/stubs/effect_render_oscilloscope_star.cpp
@@ -1,0 +1,10 @@
+#include "effects/stubs/effect_render_oscilloscope_star.h"
+
+
+Effect_RenderOscilloscopeStar::Effect_RenderOscilloscopeStar() : Effect("Render / Oscilloscope Star") {}
+
+bool Effect_RenderOscilloscopeStar::render(avs::core::RenderContext& context) {
+  (void)context;
+  // TODO: Implement per R_OscStars in r_oscstar.cpp
+  return true;
+}

--- a/src/effects/stubs/effect_render_oscilloscope_star.h
+++ b/src/effects/stubs/effect_render_oscilloscope_star.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "effects/effect.h"
+
+class Effect_RenderOscilloscopeStar : public Effect {
+ public:
+  Effect_RenderOscilloscopeStar();
+  ~Effect_RenderOscilloscopeStar() override = default;
+
+  bool render(avs::core::RenderContext& context) override;
+};

--- a/src/effects/stubs/effect_render_ring.cpp
+++ b/src/effects/stubs/effect_render_ring.cpp
@@ -1,0 +1,10 @@
+#include "effects/stubs/effect_render_ring.h"
+
+
+Effect_RenderRing::Effect_RenderRing() : Effect("Render / Ring") {}
+
+bool Effect_RenderRing::render(avs::core::RenderContext& context) {
+  (void)context;
+  // TODO: Implement per R_OscRings in r_oscring.cpp
+  return true;
+}

--- a/src/effects/stubs/effect_render_ring.h
+++ b/src/effects/stubs/effect_render_ring.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "effects/effect.h"
+
+class Effect_RenderRing : public Effect {
+ public:
+  Effect_RenderRing();
+  ~Effect_RenderRing() override = default;
+
+  bool render(avs::core::RenderContext& context) override;
+};

--- a/src/effects/stubs/effect_render_rotating_stars.cpp
+++ b/src/effects/stubs/effect_render_rotating_stars.cpp
@@ -1,0 +1,10 @@
+#include "effects/stubs/effect_render_rotating_stars.h"
+
+
+Effect_RenderRotatingStars::Effect_RenderRotatingStars() : Effect("Render / Rotating Stars") {}
+
+bool Effect_RenderRotatingStars::render(avs::core::RenderContext& context) {
+  (void)context;
+  // TODO: Implement per R_RotStar in r_rotstar.cpp
+  return true;
+}

--- a/src/effects/stubs/effect_render_rotating_stars.h
+++ b/src/effects/stubs/effect_render_rotating_stars.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "effects/effect.h"
+
+class Effect_RenderRotatingStars : public Effect {
+ public:
+  Effect_RenderRotatingStars();
+  ~Effect_RenderRotatingStars() override = default;
+
+  bool render(avs::core::RenderContext& context) override;
+};

--- a/src/effects/stubs/effect_render_simple.cpp
+++ b/src/effects/stubs/effect_render_simple.cpp
@@ -1,0 +1,10 @@
+#include "effects/stubs/effect_render_simple.h"
+
+
+Effect_RenderSimple::Effect_RenderSimple() : Effect("Render / Simple") {}
+
+bool Effect_RenderSimple::render(avs::core::RenderContext& context) {
+  (void)context;
+  // TODO: Implement per R_SimpleSpectrum in r_simple.cpp
+  return true;
+}

--- a/src/effects/stubs/effect_render_simple.h
+++ b/src/effects/stubs/effect_render_simple.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "effects/effect.h"
+
+class Effect_RenderSimple : public Effect {
+ public:
+  Effect_RenderSimple();
+  ~Effect_RenderSimple() override = default;
+
+  bool render(avs::core::RenderContext& context) override;
+};

--- a/src/effects/stubs/effect_render_svp_loader.cpp
+++ b/src/effects/stubs/effect_render_svp_loader.cpp
@@ -1,0 +1,10 @@
+#include "effects/stubs/effect_render_svp_loader.h"
+
+
+Effect_RenderSvpLoader::Effect_RenderSvpLoader() : Effect("Render / SVP Loader") {}
+
+bool Effect_RenderSvpLoader::render(avs::core::RenderContext& context) {
+  (void)context;
+  // TODO: Implement per R_SVP in r_svp.cpp
+  return true;
+}

--- a/src/effects/stubs/effect_render_svp_loader.h
+++ b/src/effects/stubs/effect_render_svp_loader.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "effects/effect.h"
+
+class Effect_RenderSvpLoader : public Effect {
+ public:
+  Effect_RenderSvpLoader();
+  ~Effect_RenderSvpLoader() override = default;
+
+  bool render(avs::core::RenderContext& context) override;
+};

--- a/src/effects/stubs/effect_render_timescope.cpp
+++ b/src/effects/stubs/effect_render_timescope.cpp
@@ -1,0 +1,10 @@
+#include "effects/stubs/effect_render_timescope.h"
+
+
+Effect_RenderTimescope::Effect_RenderTimescope() : Effect("Render / Timescope") {}
+
+bool Effect_RenderTimescope::render(avs::core::RenderContext& context) {
+  (void)context;
+  // TODO: Implement per R_Timescope in r_timescope.cpp
+  return true;
+}

--- a/src/effects/stubs/effect_render_timescope.h
+++ b/src/effects/stubs/effect_render_timescope.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "effects/effect.h"
+
+class Effect_RenderTimescope : public Effect {
+ public:
+  Effect_RenderTimescope();
+  ~Effect_RenderTimescope() override = default;
+
+  bool render(avs::core::RenderContext& context) override;
+};

--- a/src/effects/stubs/effect_trans_blitter_feedback.cpp
+++ b/src/effects/stubs/effect_trans_blitter_feedback.cpp
@@ -1,0 +1,10 @@
+#include "effects/stubs/effect_trans_blitter_feedback.h"
+
+
+Effect_TransBlitterFeedback::Effect_TransBlitterFeedback() : Effect("Trans / Blitter Feedback") {}
+
+bool Effect_TransBlitterFeedback::render(avs::core::RenderContext& context) {
+  (void)context;
+  // TODO: Implement per R_BlitterFB in r_blit.cpp
+  return true;
+}

--- a/src/effects/stubs/effect_trans_blitter_feedback.h
+++ b/src/effects/stubs/effect_trans_blitter_feedback.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "effects/effect.h"
+
+class Effect_TransBlitterFeedback : public Effect {
+ public:
+  Effect_TransBlitterFeedback();
+  ~Effect_TransBlitterFeedback() override = default;
+
+  bool render(avs::core::RenderContext& context) override;
+};

--- a/src/effects/stubs/effect_trans_blur.cpp
+++ b/src/effects/stubs/effect_trans_blur.cpp
@@ -1,0 +1,10 @@
+#include "effects/stubs/effect_trans_blur.h"
+
+
+Effect_TransBlur::Effect_TransBlur() : Effect("Trans / Blur") {}
+
+bool Effect_TransBlur::render(avs::core::RenderContext& context) {
+  (void)context;
+  // TODO: Implement per R_Blur in r_blur.cpp
+  return true;
+}

--- a/src/effects/stubs/effect_trans_blur.h
+++ b/src/effects/stubs/effect_trans_blur.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "effects/effect.h"
+
+class Effect_TransBlur : public Effect {
+ public:
+  Effect_TransBlur();
+  ~Effect_TransBlur() override = default;
+
+  bool render(avs::core::RenderContext& context) override;
+};

--- a/src/effects/stubs/effect_trans_brightness.cpp
+++ b/src/effects/stubs/effect_trans_brightness.cpp
@@ -1,0 +1,10 @@
+#include "effects/stubs/effect_trans_brightness.h"
+
+
+Effect_TransBrightness::Effect_TransBrightness() : Effect("Trans / Brightness") {}
+
+bool Effect_TransBrightness::render(avs::core::RenderContext& context) {
+  (void)context;
+  // TODO: Implement per R_Brightness in r_bright.cpp
+  return true;
+}

--- a/src/effects/stubs/effect_trans_brightness.h
+++ b/src/effects/stubs/effect_trans_brightness.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "effects/effect.h"
+
+class Effect_TransBrightness : public Effect {
+ public:
+  Effect_TransBrightness();
+  ~Effect_TransBrightness() override = default;
+
+  bool render(avs::core::RenderContext& context) override;
+};

--- a/src/effects/stubs/effect_trans_color_clip.cpp
+++ b/src/effects/stubs/effect_trans_color_clip.cpp
@@ -1,0 +1,10 @@
+#include "effects/stubs/effect_trans_color_clip.h"
+
+
+Effect_TransColorClip::Effect_TransColorClip() : Effect("Trans / Color Clip") {}
+
+bool Effect_TransColorClip::render(avs::core::RenderContext& context) {
+  (void)context;
+  // TODO: Implement per R_ContrastEnhance in r_colorreplace.cpp
+  return true;
+}

--- a/src/effects/stubs/effect_trans_color_clip.h
+++ b/src/effects/stubs/effect_trans_color_clip.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "effects/effect.h"
+
+class Effect_TransColorClip : public Effect {
+ public:
+  Effect_TransColorClip();
+  ~Effect_TransColorClip() override = default;
+
+  bool render(avs::core::RenderContext& context) override;
+};

--- a/src/effects/stubs/effect_trans_color_modifier.cpp
+++ b/src/effects/stubs/effect_trans_color_modifier.cpp
@@ -1,0 +1,10 @@
+#include "effects/stubs/effect_trans_color_modifier.h"
+
+
+Effect_TransColorModifier::Effect_TransColorModifier() : Effect("Trans / Color Modifier") {}
+
+bool Effect_TransColorModifier::render(avs::core::RenderContext& context) {
+  (void)context;
+  // TODO: Implement per R_DColorMod in r_dcolormod.cpp
+  return true;
+}

--- a/src/effects/stubs/effect_trans_color_modifier.h
+++ b/src/effects/stubs/effect_trans_color_modifier.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "effects/effect.h"
+
+class Effect_TransColorModifier : public Effect {
+ public:
+  Effect_TransColorModifier();
+  ~Effect_TransColorModifier() override = default;
+
+  bool render(avs::core::RenderContext& context) override;
+};

--- a/src/effects/stubs/effect_trans_colorfade.cpp
+++ b/src/effects/stubs/effect_trans_colorfade.cpp
@@ -1,0 +1,10 @@
+#include "effects/stubs/effect_trans_colorfade.h"
+
+
+Effect_TransColorfade::Effect_TransColorfade() : Effect("Trans / Colorfade") {}
+
+bool Effect_TransColorfade::render(avs::core::RenderContext& context) {
+  (void)context;
+  // TODO: Implement per R_ColorFade in r_colorfade.cpp
+  return true;
+}

--- a/src/effects/stubs/effect_trans_colorfade.h
+++ b/src/effects/stubs/effect_trans_colorfade.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "effects/effect.h"
+
+class Effect_TransColorfade : public Effect {
+ public:
+  Effect_TransColorfade();
+  ~Effect_TransColorfade() override = default;
+
+  bool render(avs::core::RenderContext& context) override;
+};

--- a/src/effects/stubs/effect_trans_mosaic.cpp
+++ b/src/effects/stubs/effect_trans_mosaic.cpp
@@ -1,0 +1,10 @@
+#include "effects/stubs/effect_trans_mosaic.h"
+
+
+Effect_TransMosaic::Effect_TransMosaic() : Effect("Trans / Mosaic") {}
+
+bool Effect_TransMosaic::render(avs::core::RenderContext& context) {
+  (void)context;
+  // TODO: Implement per R_Mosaic in r_mosaic.cpp
+  return true;
+}

--- a/src/effects/stubs/effect_trans_mosaic.h
+++ b/src/effects/stubs/effect_trans_mosaic.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "effects/effect.h"
+
+class Effect_TransMosaic : public Effect {
+ public:
+  Effect_TransMosaic();
+  ~Effect_TransMosaic() override = default;
+
+  bool render(avs::core::RenderContext& context) override;
+};

--- a/src/effects/stubs/effect_trans_roto_blitter.cpp
+++ b/src/effects/stubs/effect_trans_roto_blitter.cpp
@@ -1,0 +1,10 @@
+#include "effects/stubs/effect_trans_roto_blitter.h"
+
+
+Effect_TransRotoBlitter::Effect_TransRotoBlitter() : Effect("Trans / Roto Blitter") {}
+
+bool Effect_TransRotoBlitter::render(avs::core::RenderContext& context) {
+  (void)context;
+  // TODO: Implement per R_RotBlit in r_rotblit.cpp
+  return true;
+}

--- a/src/effects/stubs/effect_trans_roto_blitter.h
+++ b/src/effects/stubs/effect_trans_roto_blitter.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "effects/effect.h"
+
+class Effect_TransRotoBlitter : public Effect {
+ public:
+  Effect_TransRotoBlitter();
+  ~Effect_TransRotoBlitter() override = default;
+
+  bool render(avs::core::RenderContext& context) override;
+};

--- a/src/effects/stubs/effect_trans_scatter.cpp
+++ b/src/effects/stubs/effect_trans_scatter.cpp
@@ -1,0 +1,10 @@
+#include "effects/stubs/effect_trans_scatter.h"
+
+
+Effect_TransScatter::Effect_TransScatter() : Effect("Trans / Scatter") {}
+
+bool Effect_TransScatter::render(avs::core::RenderContext& context) {
+  (void)context;
+  // TODO: Implement per R_Scat in r_scat.cpp
+  return true;
+}

--- a/src/effects/stubs/effect_trans_scatter.h
+++ b/src/effects/stubs/effect_trans_scatter.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "effects/effect.h"
+
+class Effect_TransScatter : public Effect {
+ public:
+  Effect_TransScatter();
+  ~Effect_TransScatter() override = default;
+
+  bool render(avs::core::RenderContext& context) override;
+};

--- a/src/effects/stubs/effect_trans_unique_tone.cpp
+++ b/src/effects/stubs/effect_trans_unique_tone.cpp
@@ -1,0 +1,10 @@
+#include "effects/stubs/effect_trans_unique_tone.h"
+
+
+Effect_TransUniqueTone::Effect_TransUniqueTone() : Effect("Trans / Unique tone") {}
+
+bool Effect_TransUniqueTone::render(avs::core::RenderContext& context) {
+  (void)context;
+  // TODO: Implement per R_Onetone in r_onetone.cpp
+  return true;
+}

--- a/src/effects/stubs/effect_trans_unique_tone.h
+++ b/src/effects/stubs/effect_trans_unique_tone.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "effects/effect.h"
+
+class Effect_TransUniqueTone : public Effect {
+ public:
+  Effect_TransUniqueTone();
+  ~Effect_TransUniqueTone() override = default;
+
+  bool render(avs::core::RenderContext& context) override;
+};

--- a/src/effects/stubs/effect_trans_water.cpp
+++ b/src/effects/stubs/effect_trans_water.cpp
@@ -1,0 +1,10 @@
+#include "effects/stubs/effect_trans_water.h"
+
+
+Effect_TransWater::Effect_TransWater() : Effect("Trans / Water") {}
+
+bool Effect_TransWater::render(avs::core::RenderContext& context) {
+  (void)context;
+  // TODO: Implement per R_Water in r_water.cpp
+  return true;
+}

--- a/src/effects/stubs/effect_trans_water.h
+++ b/src/effects/stubs/effect_trans_water.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "effects/effect.h"
+
+class Effect_TransWater : public Effect {
+ public:
+  Effect_TransWater();
+  ~Effect_TransWater() override = default;
+
+  bool render(avs::core::RenderContext& context) override;
+};

--- a/src/effects/stubs/effect_trans_water_bump.cpp
+++ b/src/effects/stubs/effect_trans_water_bump.cpp
@@ -1,0 +1,10 @@
+#include "effects/stubs/effect_trans_water_bump.h"
+
+
+Effect_TransWaterBump::Effect_TransWaterBump() : Effect("Trans / Water Bump") {}
+
+bool Effect_TransWaterBump::render(avs::core::RenderContext& context) {
+  (void)context;
+  // TODO: Implement per R_WaterBump in r_waterbump.cpp
+  return true;
+}

--- a/src/effects/stubs/effect_trans_water_bump.h
+++ b/src/effects/stubs/effect_trans_water_bump.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "effects/effect.h"
+
+class Effect_TransWaterBump : public Effect {
+ public:
+  Effect_TransWaterBump();
+  ~Effect_TransWaterBump() override = default;
+
+  bool render(avs::core::RenderContext& context) override;
+};

--- a/src/runtime/parser.cpp
+++ b/src/runtime/parser.cpp
@@ -1,0 +1,69 @@
+#include "runtime/parser.h"
+
+#include <algorithm>
+#include <cctype>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+
+namespace {
+
+std::string toLowerCopy(std::string_view value) {
+  std::string result(value);
+  std::transform(result.begin(), result.end(), result.begin(), [](unsigned char ch) {
+    return static_cast<char>(std::tolower(ch));
+  });
+  return result;
+}
+
+const std::unordered_map<std::string, std::string>& stubEffectTokens() {
+  static const std::unordered_map<std::string, std::string> tokens = {
+      {"channel shift", "channel shift"},
+      {"color reduction", "color reduction"},
+      {"holden04: video delay", "holden04: video delay"},
+      {"holden05: multi delay", "holden05: multi delay"},
+      {"misc / comment", "misc / comment"},
+      {"misc / custom bpm", "misc / custom bpm"},
+      {"misc / set render mode", "misc / set render mode"},
+      {"multiplier", "multiplier"},
+      {"render / avi", "render / avi"},
+      {"render / bass spin", "render / bass spin"},
+      {"render / dot fountain", "render / dot fountain"},
+      {"render / dot plane", "render / dot plane"},
+      {"render / moving particle", "render / moving particle"},
+      {"render / oscilloscope star", "render / oscilloscope star"},
+      {"render / ring", "render / ring"},
+      {"render / rotating stars", "render / rotating stars"},
+      {"render / simple", "render / simple"},
+      {"render / svp loader", "render / svp loader"},
+      {"render / timescope", "render / timescope"},
+      {"trans / blitter feedback", "trans / blitter feedback"},
+      {"trans / blur", "trans / blur"},
+      {"trans / brightness", "trans / brightness"},
+      {"trans / color clip", "trans / color clip"},
+      {"trans / color modifier", "trans / color modifier"},
+      {"trans / colorfade", "trans / colorfade"},
+      {"trans / mosaic", "trans / mosaic"},
+      {"trans / roto blitter", "trans / roto blitter"},
+      {"trans / scatter", "trans / scatter"},
+      {"trans / unique tone", "trans / unique tone"},
+      {"trans / water", "trans / water"},
+      {"trans / water bump", "trans / water bump"},
+  };
+  return tokens;
+}
+
+}  // namespace
+
+namespace avs::runtime::parser {
+
+std::string normalizeEffectToken(std::string_view token) {
+  const std::string lowered = toLowerCopy(token);
+  const auto& tokens = stubEffectTokens();
+  if (auto it = tokens.find(lowered); it != tokens.end()) {
+    return it->second;
+  }
+  return lowered;
+}
+
+}  // namespace avs::runtime::parser

--- a/src/runtime/parser.h
+++ b/src/runtime/parser.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <string>
+#include <string_view>
+
+namespace avs::runtime::parser {
+
+std::string normalizeEffectToken(std::string_view token);
+
+}  // namespace avs::runtime::parser


### PR DESCRIPTION
## Summary
- add a shared stub effect base with logging and hook all missing legacy AVS render/trans/misc modules into the registry
- normalize preset parsing for legacy token names and register lowercase/original variants so legacy presets resolve without errors
- document each stub and record their original sources in the compatibility manifest

## Testing
- cmake -S . -B build *(fails: PortAudio not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68f0a8c3dfc4832ca013c58ab9765f30