### PR TITLE
Fix build configuration for avs effects

### DIFF
--- a/libs/avs-core/CMakeLists.txt
+++ b/libs/avs-core/CMakeLists.txt
@@ -30,17 +30,18 @@ target_include_directories(avs-core
   PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/libs/avs-platform/include>
-    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
-target_include_directories(avs-core
-  PRIVATE
-    ${CMAKE_CURRENT_SOURCE_DIR}/src)
-    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/libs/avs/runtime/include>
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
   PRIVATE
-    ${CMAKE_SOURCE_DIR}/libs/third_party)
+    ${CMAKE_CURRENT_SOURCE_DIR}/src
+    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/libs/avs/runtime/include>
+    ${CMAKE_SOURCE_DIR}/libs/third_party
+)
 target_compile_options(avs-core PRIVATE -Wall -Wextra -Werror)
 target_compile_features(avs-core PUBLIC cxx_std_20)
-target_link_libraries(avs-core PUBLIC ns-eel)
+target_link_libraries(avs-core
+  PUBLIC
+    ns-eel
+    avs-runtime)
 add_executable(avs_headless src/headless_main.cpp)
 target_link_libraries(avs_headless PRIVATE avs-core)
 target_compile_options(avs_headless PRIVATE -Wall -Wextra -Werror)

--- a/libs/avs-core/src/effects_render.cpp
+++ b/libs/avs-core/src/effects_render.cpp
@@ -210,13 +210,6 @@ void StarfieldEffect::process(const ProcessContext& ctx, FrameBufferView& dst) {
 }
 
 // ---------------- Text / Picture / Superscope / Triangles / Shapes / DotGrid ----------------
-std::vector<Param> PictureEffect::parameters() const { return {}; }
-void PictureEffect::process(const ProcessContext&, FrameBufferView&) {}
-
-// Stubs for now.
-std::vector<Param> TextEffect::parameters() const { return {}; }
-void TextEffect::process(const ProcessContext&, FrameBufferView&) {}
-
 std::vector<Param> PictureEffect::parameters() const {
   return {Param{"path", ParamKind::String, path_}};
 }

--- a/libs/avs/effects/CMakeLists.txt
+++ b/libs/avs/effects/CMakeLists.txt
@@ -38,8 +38,9 @@ set(AVS_EFFECT_STUB_SOURCES
   ${CMAKE_SOURCE_DIR}/src/effects/dynamic/dyn_shift.cpp
   ${CMAKE_SOURCE_DIR}/src/effects/dynamic/movement.cpp
   ${CMAKE_SOURCE_DIR}/src/effects/dynamic/zoom_rotate.cpp
-  ${CMAKE_SOURCE_DIR}/src/runtime/parser.cpp)
-  ${CMAKE_SOURCE_DIR}/src/runtime/framebuffers.cpp)
+  ${CMAKE_SOURCE_DIR}/src/runtime/parser.cpp
+  ${CMAKE_SOURCE_DIR}/src/runtime/framebuffers.cpp
+)
 
 add_library(avs-effects-core
   src/Bump.cpp


### PR DESCRIPTION
## Summary
- fix the avs-effects stub source list so the project configures cleanly
- consolidate avs-core include directories and link it against avs-runtime
- drop duplicate TextEffect stubs that conflicted with the implemented geometry effect

## Testing
- cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release
- cmake --build build
- ctest --output-on-failure --test-dir build


------
https://chatgpt.com/codex/tasks/task_e_68f0c58fc840832ca807d9736c7b2d2a