### PR TITLE
Fix effect list parser array closing bracket handling

### DIFF
--- a/libs/avs-core/src/effects_misc.cpp
+++ b/libs/avs-core/src/effects_misc.cpp
@@ -65,7 +65,7 @@ class EffectListConfigParser {
       get();
       if (!parseArray(out)) return false;
       skipWhitespace();
-      return consume(']') && skipTrailing();
+      return skipTrailing();
     }
     EffectListEffect::ConfigNode node;
     if (!parseObject(node)) return false;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -101,6 +101,13 @@ if(TARGET avs-resources)
   add_dependencies(runtime_resource_tests avs-resources)
 endif()
 
+add_executable(runtime_effect_list_parser_tests
+  runtime/parser/effect_list_parser_tests.cpp)
+target_link_libraries(runtime_effect_list_parser_tests PRIVATE avs-core avs-runtime GTest::gtest_main)
+target_compile_options(runtime_effect_list_parser_tests PRIVATE -Wall -Wextra -Werror)
+target_compile_definitions(runtime_effect_list_parser_tests PRIVATE BUILD_DIR="${CMAKE_BINARY_DIR}" SOURCE_DIR="${CMAKE_SOURCE_DIR}")
+add_test(NAME runtime_effect_list_parser_tests COMMAND runtime_effect_list_parser_tests)
+
 
 if(AVS_BUILD_AUDIO)
   add_executable(offscreen_golden_test

--- a/tests/runtime/parser/effect_list_parser_tests.cpp
+++ b/tests/runtime/parser/effect_list_parser_tests.cpp
@@ -1,0 +1,89 @@
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "avs/effect.hpp"
+#include "avs/effects_misc.hpp"
+
+namespace {
+
+class CountingEffect : public avs::IEffect {
+ public:
+  explicit CountingEffect(int& counter) : counter_(&counter) { ++(*counter_); }
+
+  avs::EffectGroup group() const override { return avs::EffectGroup::Misc; }
+  std::string_view name() const override { return "counting"; }
+  void process(const avs::ProcessContext&, avs::FrameBufferView&) override {}
+
+ private:
+  int* counter_;
+};
+
+}  // namespace
+
+TEST(EffectListConfigParser, AcceptsEmptyArray) {
+  avs::EffectListEffect effect;
+  int constructed = 0;
+  std::vector<std::string> ids;
+  effect.setFactory([&](std::string_view id) {
+    ids.emplace_back(id);
+    return std::make_unique<CountingEffect>(constructed);
+  });
+
+  effect.set_parameter("config", std::string("[]"));
+
+  EXPECT_TRUE(ids.empty());
+  EXPECT_EQ(constructed, 0);
+}
+
+TEST(EffectListConfigParser, ParsesSingleEffect) {
+  avs::EffectListEffect effect;
+  int constructed = 0;
+  std::vector<std::string> ids;
+  effect.setFactory([&](std::string_view id) {
+    ids.emplace_back(id);
+    return std::make_unique<CountingEffect>(constructed);
+  });
+
+  effect.set_parameter("config", std::string("[{\"effect\":\"foo\"}]"));
+
+  ASSERT_EQ(ids.size(), 1u);
+  EXPECT_EQ(ids.front(), "foo");
+  EXPECT_EQ(constructed, 1);
+}
+
+TEST(EffectListConfigParser, ParsesMultipleEffects) {
+  avs::EffectListEffect effect;
+  int constructed = 0;
+  std::vector<std::string> ids;
+  effect.setFactory([&](std::string_view id) {
+    ids.emplace_back(id);
+    return std::make_unique<CountingEffect>(constructed);
+  });
+
+  effect.set_parameter(
+      "config", std::string("[{\"effect\":\"foo\"},{\"effect\":\"bar\"}]"));
+
+  ASSERT_EQ(ids.size(), 2u);
+  EXPECT_EQ(ids[0], "foo");
+  EXPECT_EQ(ids[1], "bar");
+  EXPECT_EQ(constructed, 2);
+}
+
+TEST(EffectListConfigParser, RejectsInvalidArray) {
+  avs::EffectListEffect effect;
+  int constructed = 0;
+  std::vector<std::string> ids;
+  effect.setFactory([&](std::string_view id) {
+    ids.emplace_back(id);
+    return std::make_unique<CountingEffect>(constructed);
+  });
+
+  effect.set_parameter("config", std::string("[invalid]"));
+
+  EXPECT_TRUE(ids.empty());
+  EXPECT_EQ(constructed, 0);
+}


### PR DESCRIPTION
## Summary
- stop double-consuming the closing bracket in `EffectListConfigParser` so array inputs parse correctly
- add regression tests for empty, single, multiple, and invalid array configurations
- hook the new parser tests into the tests CMake target list

## Testing
- cmake -S . -B build -DAVS_BUILD_AUDIO=OFF -DAVS_BUILD_PLATFORM=OFF
- cmake --build build --target runtime_effect_list_parser_tests
- ctest -R runtime_effect_list_parser_tests


------
https://chatgpt.com/codex/tasks/task_e_68f0c98d23f0832c94dccab377faddd6