### PR TITLE
Improve dependency setup guidance for PortAudio

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,12 +2,20 @@
 
 ## Setup Commands
 
+* **Provision dependencies (mirrors CI)**
+
+  ```bash
+  # Installs the same packages that CI pulls in, including PortAudio dev files.
+  ./run_setup_dev_environment.sh --platform ubuntu
+  # Use --platform fedora when working inside a Fedora container.
+  ```
+
 * **Clone and configure**
 
-```bash
-git clone https://github.com/pfahlr/vis_avs.git
-cd avs-port
-mkdir build && cd build
+  ```bash
+  git clone https://github.com/pfahlr/vis_avs.git
+  cd avs-port
+  mkdir build && cd build
 cmake .. -DCMAKE_BUILD_TYPE=Debug
 ```
 
@@ -28,11 +36,16 @@ cmake --build . -j"$(nproc)"
   * Build essentials: `cmake g++ clang-format git`
   * SDL2: `libsdl2-dev`
   * OpenGL: `mesa-common-dev libglu1-mesa-dev`
-  * PortAudio: `portaudio19-dev libportaudio2`
+  * PortAudio: `portaudio19-dev libportaudio2` (Ubuntu) / `portaudio-devel` (Fedora)
   * KissFFT: vendored (no system package required)
   * GoogleTest: `libgtest-dev` (or FetchContent in CMake)
   * ImGui (optional): vendored
   * **Note:** If JACK or ALSA backends are missing, install `libjack-dev` and `libasound2-dev`.
+
+  **Important:** The development container allows installing these packages. Run
+  `./run_setup_dev_environment.sh` before configuring CMake so PortAudio is
+  available; skipping this step will cause `cmake` to fail with a missing
+  PortAudio error.
 
 **All dependencies listed here must be mirrored in `/.github/workflows/ci.yml`.**
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,9 +7,17 @@ portable engine and tooling.
 
 ## Prerequisites
 
-Ensure the following packages are installed:
+Ensure the following packages are installed. The helper script mirrors the CI
+environment and pulls in the PortAudio development headers automatically.
 
 ```bash
+# Ubuntu container
+./run_setup_dev_environment.sh --platform ubuntu
+
+# Fedora container
+./run_setup_dev_environment.sh --platform fedora
+
+# Manual apt invocation (Ubuntu) if you prefer running the commands yourself
 sudo apt-get install cmake g++ clang-format git pkg-config \
   libsdl2-dev mesa-common-dev libglu1-mesa-dev \
   portaudio19-dev libportaudio2 libgtest-dev libsamplerate0-dev \

--- a/run_setup_dev_environment.sh
+++ b/run_setup_dev_environment.sh
@@ -1,68 +1,116 @@
 #!/bin/bash
 
+set -euo pipefail
+
 function print_help {
   echo "usage $0 <options>"
   echo "options:"
   echo "  --help: print this help screen"
-  echo "  --platform <value>: which linux distro to setup"
+  echo "  --platform <value>: which linux distro to setup (ubuntu|fedora)"
   echo "  --dryrun: don't actually run, just print what it would have done"
 }
 
-PLATFORM="ubuntu"
+platform="ubuntu"
+dryrun=false
 
-#parse arguments
-while [ $# -gt 0 ]; do
-    case "$1" in
-       	--help)
-            print_help;
-            exit 0
-            ;;
-        --platform)
-            platform="$2"
-            shift 2
-            ;;
-        --dryrun)
-            dryrun="True"
-            shift 1
-            ;;
-        *)
-            # Handle positional arguments or unknown options
-            text=$1
-            shift 1
-            ;;
-    esac
-done
-
-# validate argument values
-if [[ ! -z "$platform" ]]; then
-  case "$platform" in 
-    ubuntu)
-      PLATFORM="ubuntu";
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --help)
+      print_help
+      exit 0
       ;;
-    fedora)
-      PLATFORM="fedora"
+    --platform)
+      if [[ $# -lt 2 ]]; then
+        echo "--platform requires an argument" >&2
+        exit 1
+      fi
+      platform="$2"
+      shift 2
+      ;;
+    --dryrun)
+      dryrun=true
+      shift 1
       ;;
     *)
-      echo "$platform not supported"
-      exit 0
+      echo "Unknown option: $1" >&2
+      exit 1
+      ;;
   esac
+done
+
+case "$platform" in
+  ubuntu|fedora)
+    ;;
+  *)
+    echo "$platform not supported" >&2
+    exit 1
+    ;;
+esac
+
+if command -v sudo >/dev/null 2>&1 && [[ "$EUID" -ne 0 ]]; then
+  sudo_cmd=(sudo)
+else
+  sudo_cmd=()
 fi
 
-# run build enviornment setup
-case $PLATFORM in 
-    ubuntu)
-       if [[ $dryrun == "True" ]]; then
-         echo "dryrun ubuntu"
-       else
-         echo "installing ubuntu build system"
-       sudo apt-get install cmake g++ clang-format git pkg-config \
-       libsdl2-dev mesa-common-dev libglu1-mesa-dev \
-       portaudio19-dev libportaudio2 libgtest-dev libsamplerate0-dev \
-       libjack-dev libasound2-dev
-       fi
-       ;;
-    fedora)
-       echo "fedora not implemented yet"
-       ;;
+run_cmd() {
+  if [[ "$dryrun" == true ]]; then
+    printf '[dryrun]'
+    for arg in "$@"; do
+      printf ' %q' "$arg"
+    done
+    printf '\n'
+  else
+    "$@"
+  fi
+}
+
+case "$platform" in
+  ubuntu)
+    packages=(
+      build-essential
+      clang
+      cmake
+      git
+      ninja-build
+      pkg-config
+      python3
+      libsdl2-dev
+      libgl1-mesa-dev
+      libglu1-mesa-dev
+      libasound2-dev
+      libjack-dev
+      libportaudio2
+      portaudio19-dev
+      libsamplerate0-dev
+      libfftw3-dev
+    )
+    echo "Installing Ubuntu build dependencies (mirrors CI)"
+    run_cmd "${sudo_cmd[@]}" apt-get update
+    run_cmd "${sudo_cmd[@]}" apt-get install -y --no-install-recommends "${packages[@]}"
+    ;;
+  fedora)
+    packages=(
+      clang
+      cmake
+      gcc
+      gcc-c++
+      git
+      ninja-build
+      pkgconf-pkg-config
+      python3
+      SDL2-devel
+      mesa-libGL-devel
+      mesa-libGLU-devel
+      alsa-lib-devel
+      jack-audio-connection-kit-devel
+      portaudio-devel
+      libsamplerate-devel
+      fftw-devel
+    )
+    echo "Installing Fedora build dependencies (mirrors CI)"
+    run_cmd "${sudo_cmd[@]}" dnf -y makecache
+    run_cmd "${sudo_cmd[@]}" dnf -y install "${packages[@]}"
+    ;;
 esac
 


### PR DESCRIPTION
## Summary
- document the dependency provisioning step in AGENTS.md and note that PortAudio packages are available in the container
- update the developer README to reference the setup helper script and mirror the CI installation instructions
- expand the setup script to mirror CI for Ubuntu and Fedora, add dry-run logging, and make it executable

## Testing
- ./run_setup_dev_environment.sh --dryrun --platform ubuntu
- ./run_setup_dev_environment.sh --dryrun --platform fedora

------
https://chatgpt.com/codex/tasks/task_e_68f7f5f57d34832cad8740157ecb3676