### PR TITLE
fix: remove stale channel shift stub reference

### DIFF
--- a/libs/avs/effects/CMakeLists.txt
+++ b/libs/avs/effects/CMakeLists.txt
@@ -1,6 +1,5 @@
 set(AVS_EFFECT_STUB_SOURCES
   ${CMAKE_SOURCE_DIR}/src/effects/effect.cpp
-  ${CMAKE_SOURCE_DIR}/src/effects/stubs/effect_channel_shift.cpp
   ${CMAKE_SOURCE_DIR}/src/effects/stubs/effect_color_reduction.cpp
   ${CMAKE_SOURCE_DIR}/src/effects/stubs/effect_holden04_video_delay.cpp
   ${CMAKE_SOURCE_DIR}/src/effects/stubs/effect_holden05_multi_delay.cpp


### PR DESCRIPTION
## Summary
- remove the obsolete channel shift stub source from the avs-effects-core target so configuration succeeds when the real implementation is present

## Testing
- cmake -S . -B build *(fails: PortAudio dev package missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68f7fa84a9c8832caace0e7e9f6bd101