### PR TITLE
fix: skip missing effect stubs during configure

### DIFF
--- a/libs/avs/effects/CMakeLists.txt
+++ b/libs/avs/effects/CMakeLists.txt
@@ -40,6 +40,20 @@ set(AVS_EFFECT_STUB_SOURCES
   ${CMAKE_SOURCE_DIR}/src/runtime/framebuffers.cpp
 )
 
+# Some stub sources are still TODO in the repository.  Filter out any entries
+# that are referenced here but do not exist locally so CMake does not fail when
+# new environments (like the Codespace container) have not generated them yet.
+set(_avs_effect_stubs_filtered "")
+foreach(_avs_effect_stub ${AVS_EFFECT_STUB_SOURCES})
+  if(EXISTS "${_avs_effect_stub}")
+    list(APPEND _avs_effect_stubs_filtered "${_avs_effect_stub}")
+  else()
+    message(STATUS "Skipping missing AVS effect stub: ${_avs_effect_stub}")
+  endif()
+endforeach()
+set(AVS_EFFECT_STUB_SOURCES ${_avs_effect_stubs_filtered})
+unset(_avs_effect_stubs_filtered)
+
 add_library(avs-effects-core
   src/Bump.cpp
   src/Blend.cpp

--- a/libs/avs/effects/src/RegisterEffects.cpp
+++ b/libs/avs/effects/src/RegisterEffects.cpp
@@ -28,7 +28,6 @@
 #include "effects/trans/effect_channel_shift.h"
 #include "effects/trans/effect_multi_delay.h"
 #include "effects/trans/effect_video_delay.h"
-#include "effects/stubs/effect_misc_comment.h"
 #include "effects/misc/effect_render_mode.h"
 #include "effects/misc/effect_custom_bpm.h"
 #include "effects/trans/effect_multiplier.h"


### PR DESCRIPTION
## Summary
- filter out effect stub sources that are referenced but not present so configuration succeeds
- drop the include of the non-existent stub header in the effect registry

## Testing
- cmake -S . -B build
- cmake --build build -j2
- ctest


------
https://chatgpt.com/codex/tasks/task_e_68f7fbc2291c832c97d27b03677b3bad