### PR TITLE
Fix missing Render AVI stub registration

### DIFF
--- a/libs/avs/effects/CMakeLists.txt
+++ b/libs/avs/effects/CMakeLists.txt
@@ -9,6 +9,7 @@ set(AVS_EFFECT_STUB_SOURCES
   ${CMAKE_SOURCE_DIR}/src/effects/stubs/effect_render_rotating_stars.cpp
 
   ${CMAKE_SOURCE_DIR}/src/effects/stubs/effect_render_simple.cpp
+  ${CMAKE_SOURCE_DIR}/src/effects/stubs/effect_render_avi.cpp
   ${CMAKE_SOURCE_DIR}/src/effects/stubs/effect_render_svp_loader.cpp
   ${CMAKE_SOURCE_DIR}/src/effects/stubs/effect_render_timescope.cpp
   ${CMAKE_SOURCE_DIR}/src/effects/stubs/effect_trans_blitter_feedback.cpp


### PR DESCRIPTION
## Summary
- include the Render / AVI stub implementation in the avs-effects-core library so the effect factory can link successfully

## Testing
- ⚠️ `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release` *(fails: PortAudio not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68f8045a327c832caf5e7818222fdc92