### PR TITLE
Fix duplicate trans effects test target

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -98,13 +98,6 @@ target_compile_definitions(dynamic_effects_tests PRIVATE BUILD_DIR="${CMAKE_BINA
 target_include_directories(dynamic_effects_tests PRIVATE ${CMAKE_SOURCE_DIR}/tests/presets/fb_ops)
 add_test(NAME dynamic_effects_tests COMMAND dynamic_effects_tests)
 
-add_executable(trans_effects_tests
-  presets/trans/test_blitter_feedback.cpp)
-target_link_libraries(trans_effects_tests PRIVATE avs-effects-core avs-core-runtime avs-offscreen GTest::gtest_main)
-target_compile_options(trans_effects_tests PRIVATE -Wall -Wextra -Werror)
-target_compile_definitions(trans_effects_tests PRIVATE BUILD_DIR="${CMAKE_BINARY_DIR}" SOURCE_DIR="${CMAKE_SOURCE_DIR}")
-add_test(NAME trans_effects_tests COMMAND trans_effects_tests)
-
 add_executable(filter_effects_tests
   presets/filters/test_filters.cpp)
 target_link_libraries(filter_effects_tests PRIVATE avs-effects-core avs-core-runtime avs-offscreen GTest::gtest_main)
@@ -113,6 +106,7 @@ target_compile_definitions(filter_effects_tests PRIVATE BUILD_DIR="${CMAKE_BINAR
 add_test(NAME filter_effects_tests COMMAND filter_effects_tests)
 
 add_executable(trans_effects_tests
+  presets/trans/test_blitter_feedback.cpp
   presets/trans/test_trans.cpp
   presets/trans/test_trans_blur.cpp)
 


### PR DESCRIPTION
## Summary
- merge the transitional effects test sources into a single trans_effects_tests target
- prevent CMake from defining the same executable twice

## Testing
- cmake -S . -B build *(fails: PortAudio not found in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f80a4c3848832cb803d65a1a9b4b98