### PR TITLE
Fix missing Render AVI effect stub linkage

### DIFF
--- a/libs/avs/effects/CMakeLists.txt
+++ b/libs/avs/effects/CMakeLists.txt
@@ -6,7 +6,7 @@ set(AVS_EFFECT_STUB_SOURCES
 #  ${CMAKE_SOURCE_DIR}/src/effects/stubs/effect_render_ring.cpp
 #  ${CMAKE_SOURCE_DIR}/src/effects/stubs/effect_render_rotating_stars.cpp
   ${CMAKE_SOURCE_DIR}/src/effects/stubs/effect_render_simple.cpp
-#  ${CMAKE_SOURCE_DIR}/src/effects/stubs/effect_render_avi.cpp
+  ${CMAKE_SOURCE_DIR}/src/effects/stubs/effect_render_avi.cpp
   ${CMAKE_SOURCE_DIR}/src/effects/stubs/effect_render_svp_loader.cpp
   ${CMAKE_SOURCE_DIR}/src/effects/stubs/effect_render_timescope.cpp
 #  ${CMAKE_SOURCE_DIR}/src/effects/stubs/effect_trans_blitter_feedback.cpp


### PR DESCRIPTION
### Summary
Closes: n/a • Job: n/a

- Ensure the Render / AVI stub effect is compiled into the core effects library so registration resolves at link time.

### Checklist
- [x] Steps completed (map each step to a commit or note)
- [x] Acceptance criteria satisfied
- [ ] Tests added/updated and passing (`ctest`)
- [ ] Warnings treated as errors (`-Werror`) clean
- [x] No binary blobs committed
- [ ] If binaries required for review, ZIP artifact attached (name: `binary-assets-<branch>.zip`)

### Notes
- CMake configuration fails locally because PortAudio development files are unavailable in the container; tests could not be executed.
- Device/sample-rate notes (if audio): n/a
- Preset/parser fixtures updated: n/a

------
https://chatgpt.com/codex/tasks/task_e_68f80b99f108832c8bb97c52cc1f5e3c