### PR TITLE
docs: remind codex to install build deps before cmake

### DIFF
--- a/codex/intake.md
+++ b/codex/intake.md
@@ -5,3 +5,13 @@
 - Follow the schema documented in AGENTS.md (id, title, status, labels, depends_on, goal, steps, acceptance_criteria, test_hook, files_touched).
 - Respect `codex/policies.md` (no binaries in PRs; warnings as errors).
 
+## Environment bootstrapping (must do before configuring CMake)
+
+- **Install build dependencies first.** Run the dev-environment helper before any `cmake` invocation so PortAudio and the other required packages are available inside the container:
+
+  ```bash
+  ./run_setup_dev_environment.sh --platform ubuntu
+  ```
+
+  Use `--platform fedora` when working from a Fedora base image. Skipping this step causes `cmake -S . -B build` to fail with "PortAudio not found" because the headers and libraries are missing.
+- After dependencies are installed, continue with the normal workflow (`cmake -S . -B build`, `cmake --build build`, `ctest`, …).


### PR DESCRIPTION
## Summary
- highlight the requirement to run `./run_setup_dev_environment.sh` before invoking CMake so PortAudio is available inside the container

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68f80b3e1764832ca07fb53c10d21fb5