### PR TITLE
Fix trans blur registration collision with filter alias

### DIFF
--- a/docs/effects/filters.md
+++ b/docs/effects/filters.md
@@ -15,6 +15,8 @@ explicitly noted.
 | `radius` | int | `1` | Radius of the box filter in pixels. Values are clamped to the range `[0, 32]`. |
 | `preserve_alpha` | bool | `true` | When enabled, the original alpha channel is copied back after blurring the RGB channels. |
 
+Legacy presets may also reference this effect as `Filter / Blur` (case-insensitive).
+
 The implementation performs a separable, edge-clamped box blur. The effect uses
 prefix-sum windows to avoid per-tap branching while ensuring deterministic
 results across platforms. The render-list effect `Trans / Blur` is implemented

--- a/libs/avs/effects/src/RegisterEffects.cpp
+++ b/libs/avs/effects/src/RegisterEffects.cpp
@@ -147,8 +147,8 @@ void registerCoreEffects(avs::core::EffectRegistry& registry) {
   registry.registerFactory("render / timescope", []() { return std::make_unique<Effect_RenderTimescope>(); });
   registry.registerFactory("Trans / Blitter Feedback", []() { return std::make_unique<trans::BlitterFeedback>(); });
   registry.registerFactory("trans / blitter feedback", []() { return std::make_unique<trans::BlitterFeedback>(); });
-  registry.registerFactory("Trans / Blur", []() { return std::make_unique<filters::BlurBox>(); });
-  registry.registerFactory("trans / blur", []() { return std::make_unique<filters::BlurBox>(); });
+  registry.registerFactory("Filter / Blur", []() { return std::make_unique<filters::BlurBox>(); });
+  registry.registerFactory("filter / blur", []() { return std::make_unique<filters::BlurBox>(); });
   registry.registerFactory("filter_blur_box", []() { return std::make_unique<filters::BlurBox>(); });
   registry.registerFactory("Trans / Blur", []() { return std::make_unique<trans::R_Blur>(); });
   registry.registerFactory("trans / blur", []() { return std::make_unique<trans::R_Blur>(); });


### PR DESCRIPTION
## Summary
- stop registering `filter_blur_box` under the `Trans / Blur` alias so the real transform blur effect is instantiated
- document the legacy `Filter / Blur` alias for the box blur filter

## Testing
- ctest --output-on-failure --test-dir build

------
https://chatgpt.com/codex/tasks/task_e_68f81a5e45d8832c910c85f55bba632b