### PR TITLE
fix: preserve water ripple history

### DIFF
--- a/src/effects/trans/effect_water.cpp
+++ b/src/effects/trans/effect_water.cpp
@@ -103,7 +103,7 @@ bool Water::render(avs::core::RenderContext& context) {
     }
   }
 
-  std::memcpy(lastFrame_.data(), src, requiredBytes);
+  std::memcpy(lastFrame_.data(), dst, requiredBytes);
   std::memcpy(context.framebuffer.data, dst, requiredBytes);
 
   return true;


### PR DESCRIPTION
## Summary
- ensure the water ripple effect stores its previously rendered output so the simulation state persists across frames

## Testing
- not run (explain why): manual validation required a full renderer setup outside the scope of this change


------
https://chatgpt.com/codex/tasks/task_e_68f81e155314832c8f78af0e232aeb23