### PR TITLE
fix: keep dot plane gradient in sync with height updates

### DIFF
--- a/src/effects/render/effect_dot_plane.h
+++ b/src/effects/render/effect_dot_plane.h
@@ -33,6 +33,7 @@ class DotPlane : public avs::core::IEffect {
                        std::size_t index);
   static Rgb decodeColor(int value);
   static std::uint32_t encodeColor(const Rgb& color);
+  std::uint32_t gradientColorForValue(float value) const;
 
   void sampleAudio(const avs::core::RenderContext& context,
                    std::array<float, kGridSize>& amplitudes) const;


### PR DESCRIPTION
## Summary
- clamp propagated height values and reuse the color gradient helper across the grid
- recompute each cell's color from the current height so the palette follows the audio-driven height field

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f81e858e60832c8acedb8e312de424