### PR TITLE
fix: correct ring effect palette RGB ordering

### DIFF
--- a/src/effects/render/effect_ring.cpp
+++ b/src/effects/render/effect_ring.cpp
@@ -99,9 +99,9 @@ bool Ring::parseColorToken(std::string_view token, Color& color) {
 
 Ring::Color Ring::colorFromInt(std::uint32_t value) {
   Color c{};
-  c.r = static_cast<std::uint8_t>(value & 0xFFu);
+  c.r = static_cast<std::uint8_t>((value >> 16) & 0xFFu);
   c.g = static_cast<std::uint8_t>((value >> 8) & 0xFFu);
-  c.b = static_cast<std::uint8_t>((value >> 16) & 0xFFu);
+  c.b = static_cast<std::uint8_t>(value & 0xFFu);
   return c;
 }
 

--- a/tests/core/test_render_ring.cpp
+++ b/tests/core/test_render_ring.cpp
@@ -74,7 +74,7 @@ TEST(RenderRingTest, OscillatorHashStable) {
 
   ASSERT_TRUE(effect.render(context));
   const std::string hash = hashFNV1a(pixels);
-  EXPECT_EQ(hash, "ce4136f2");
+  EXPECT_EQ(hash, "d8f04d66");
 }
 
 TEST(RenderRingTest, SpectrumEffectBitParsing) {
@@ -95,5 +95,5 @@ TEST(RenderRingTest, SpectrumEffectBitParsing) {
 
   ASSERT_TRUE(effect.render(context));
   const std::string hash = hashFNV1a(pixels);
-  EXPECT_EQ(hash, "44770945");
+  EXPECT_EQ(hash, "a39510b5");
 }


### PR DESCRIPTION
## Summary
- map ring effect palette integers to RGB using the documented byte order
- refresh render ring snapshot hashes to match the corrected channel mapping

## Testing
- `cmake --build build -j"$(nproc)"`
- `ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68f81e6390f4832c866669d964b3a59b