### PR TITLE
fix: correct rotating stars integer color byte order

### DIFF
--- a/src/effects/render/effect_rotating_stars.cpp
+++ b/src/effects/render/effect_rotating_stars.cpp
@@ -81,9 +81,9 @@ RotatingStars::Color RotatingStars::makeColor(std::uint8_t r, std::uint8_t g, st
 }
 
 RotatingStars::Color RotatingStars::makeColorFromInt(std::uint32_t packed) {
-  const std::uint8_t r = static_cast<std::uint8_t>(packed & 0xFFu);
+  const std::uint8_t r = static_cast<std::uint8_t>((packed >> 16u) & 0xFFu);
   const std::uint8_t g = static_cast<std::uint8_t>((packed >> 8u) & 0xFFu);
-  const std::uint8_t b = static_cast<std::uint8_t>((packed >> 16u) & 0xFFu);
+  const std::uint8_t b = static_cast<std::uint8_t>(packed & 0xFFu);
   return makeColor(r, g, b);
 }
 

--- a/tests/core/test_rotating_stars.cpp
+++ b/tests/core/test_rotating_stars.cpp
@@ -81,3 +81,30 @@ TEST(RotatingStarsEffectTest, HonorsCustomColorPalette) {
   EXPECT_EQ(pixels[maxIndex + 1u], 0u);
   EXPECT_EQ(pixels[maxIndex + 2u], 0u);
 }
+
+TEST(RotatingStarsEffectTest, InterpretsIntegerColorParamsAsRgb) {
+  avs::effects::render::RotatingStars effect;
+  avs::core::ParamBlock params;
+  params.setInt("color0", 0xFF0000);
+  effect.setParams(params);
+
+  std::vector<std::uint8_t> pixels(
+      static_cast<std::size_t>(kWidth) * static_cast<std::size_t>(kHeight) * 4u, 0u);
+  avs::audio::Analysis analysis{};
+  seedSpectrum(analysis);
+  auto context = makeContext(pixels, analysis);
+
+  ASSERT_TRUE(effect.render(context));
+
+  std::uint8_t maxRed = 0;
+  std::size_t maxIndex = 0;
+  for (std::size_t i = 0; i + 3 < pixels.size(); i += 4) {
+    if (pixels[i] > maxRed) {
+      maxRed = pixels[i];
+      maxIndex = i;
+    }
+  }
+  EXPECT_GT(maxRed, 0);
+  EXPECT_EQ(pixels[maxIndex + 1u], 0u);
+  EXPECT_EQ(pixels[maxIndex + 2u], 0u);
+}


### PR DESCRIPTION
## Summary
- align the Rotating Stars effect's integer color parsing with the 0xRRGGBB layout used elsewhere
- add a regression test to ensure integer palette colors render with the correct RGB channels

## Testing
- cmake --build build --target core_effects_tests
- ctest -R core_effects_tests --output-on-failure


------
https://chatgpt.com/codex/tasks/task_e_68f81e4b78d0832c868ccc9b01f82988