### PR TITLE
fix: honor gate hold when overriding audio beat

### DIFF
--- a/src/effects/misc/effect_custom_bpm.h
+++ b/src/effects/misc/effect_custom_bpm.h
@@ -26,12 +26,6 @@ class CustomBpmEffect : public avs::core::IEffect {
     Invert,
   };
 
-  enum class BeatAction {
-    None,
-    Set,
-    Clear,
-  };
-
   void configureGate();
   void resetState();
   [[nodiscard]] double intervalSeconds() const;


### PR DESCRIPTION
## Summary
- derive the override beat output from the gate render state so hold and sticky latches propagate
- remove the unused BeatAction bookkeeping
- add regression tests that verify audioBeat stays true during gate hold and sticky latch windows

## Testing
- ctest -R core_effects_tests

------
https://chatgpt.com/codex/tasks/task_e_68f81e96540c832cb21f7c8ed5f1f9db