### PR TITLE
Fix beat-mode video delay history retention

### DIFF
--- a/src/effects/trans/effect_video_delay.h
+++ b/src/effects/trans/effect_video_delay.h
@@ -36,6 +36,7 @@ class VideoDelay : public avs::core::IEffect {
   std::size_t frameSize_ = 0;
   std::size_t bufferFrameCount_ = 0;
   std::size_t headIndex_ = 0;
+  std::size_t filledFrameCount_ = 0;
   std::vector<std::uint8_t> buffer_;
   std::vector<std::uint8_t> scratch_;
 };

--- a/tests/core/test_video_delay.cpp
+++ b/tests/core/test_video_delay.cpp
@@ -117,6 +117,57 @@ TEST(VideoDelayEffect, BeatModeUpdatesDelay) {
   EXPECT_EQ(effect.currentDelayFrames(), 9);
 }
 
+TEST(VideoDelayEffect, BeatModeCapturesPreBeatHistory) {
+  VideoDelay effect;
+  avs::core::ParamBlock params;
+  params.setBool("enabled", true);
+  params.setBool("use_beats", true);
+  params.setInt("delay", 1);
+  effect.setParams(params);
+
+  std::array<std::uint8_t, 4> pixel{0u, 0u, 0u, 255u};
+  auto context = makeContext(pixel.data(), pixel.size());
+
+  context.audioBeat = false;
+  pixel = {10u, 0u, 0u, 255u};
+  ASSERT_TRUE(effect.render(context));
+  EXPECT_EQ(pixel[0], 10u);
+  EXPECT_EQ(pixel[1], 0u);
+  EXPECT_EQ(pixel[2], 0u);
+  EXPECT_EQ(pixel[3], 255u);
+
+  pixel = {20u, 0u, 0u, 255u};
+  ASSERT_TRUE(effect.render(context));
+  EXPECT_EQ(pixel[0], 20u);
+  EXPECT_EQ(pixel[1], 0u);
+  EXPECT_EQ(pixel[2], 0u);
+  EXPECT_EQ(pixel[3], 255u);
+
+  pixel = {30u, 0u, 0u, 255u};
+  ASSERT_TRUE(effect.render(context));
+  EXPECT_EQ(pixel[0], 30u);
+  EXPECT_EQ(pixel[1], 0u);
+  EXPECT_EQ(pixel[2], 0u);
+  EXPECT_EQ(pixel[3], 255u);
+
+  context.audioBeat = true;
+  pixel = {40u, 0u, 0u, 255u};
+  ASSERT_TRUE(effect.render(context));
+  EXPECT_EQ(pixel[0], 10u);
+  EXPECT_EQ(pixel[1], 0u);
+  EXPECT_EQ(pixel[2], 0u);
+  EXPECT_EQ(pixel[3], 255u);
+  EXPECT_EQ(effect.currentDelayFrames(), 3);
+
+  context.audioBeat = false;
+  pixel = {50u, 0u, 0u, 255u};
+  ASSERT_TRUE(effect.render(context));
+  EXPECT_EQ(pixel[0], 20u);
+  EXPECT_EQ(pixel[1], 0u);
+  EXPECT_EQ(pixel[2], 0u);
+  EXPECT_EQ(pixel[3], 255u);
+}
+
 TEST(VideoDelayEffect, ClampsBeatDelayToHistoryLimit) {
   VideoDelay effect;
   avs::core::ParamBlock params;


### PR DESCRIPTION
## Summary
- ensure VideoDelay records frames while beats mode reports zero delay and preserve buffer ordering
- track how many buffered frames are valid so beat-driven resizes keep captured history
- add a regression test that confirms pre-beat frames replay on the first non-zero delay

## Testing
- ctest --output-on-failure -R core_effects_tests

------
https://chatgpt.com/codex/tasks/task_e_68f81ed8a37c832c85561b0ff7933412