### PR TITLE
fix: prevent effect list parser from double consuming closing bracket

### DIFF
--- a/libs/avs-core/src/effects_misc.cpp
+++ b/libs/avs-core/src/effects_misc.cpp
@@ -64,6 +64,7 @@ class EffectListConfigParser {
     if (peek() == '[') {
       get();
       if (!parseArray(out)) return false;
+      if (!consume(']')) return false;
 
       skipWhitespace();
       return skipTrailing();
@@ -78,7 +79,6 @@ class EffectListConfigParser {
   bool parseArray(std::vector<EffectListEffect::ConfigNode>& out) {
     skipWhitespace();
     if (peek() == ']') {
-      get();
       return true;
     }
     while (pos_ < text_.size()) {
@@ -92,7 +92,6 @@ class EffectListConfigParser {
         continue;
       }
       if (peek() == ']') {
-        get();
         return true;
       }
       return false;
@@ -120,6 +119,7 @@ class EffectListConfigParser {
       } else if (key == "children") {
         if (!consume('[')) return false;
         if (!parseArray(node.children)) return false;
+        if (!consume(']')) return false;
       } else {
         if (!skipValue()) return false;
       }
@@ -150,6 +150,7 @@ class EffectListConfigParser {
       get();
       std::vector<EffectListEffect::ConfigNode> tmp;
       if (!parseArray(tmp)) return false;
+      if (!consume(']')) return false;
       return true;
     }
     std::size_t start = pos_;

--- a/tests/runtime/parser/effect_list_parser_tests.cpp
+++ b/tests/runtime/parser/effect_list_parser_tests.cpp
@@ -55,6 +55,22 @@ TEST(EffectListConfigParser, ParsesSingleEffect) {
   EXPECT_EQ(constructed, 1);
 }
 
+TEST(EffectListConfigParser, ParsesSingleEffectWithWhitespace) {
+  avs::EffectListEffect effect;
+  int constructed = 0;
+  std::vector<std::string> ids;
+  effect.setFactory([&](std::string_view id) {
+    ids.emplace_back(id);
+    return std::make_unique<CountingEffect>(constructed);
+  });
+
+  effect.set_parameter("config", std::string("[ {\"effect\" : \"foo\"} ]"));
+
+  ASSERT_EQ(ids.size(), 1u);
+  EXPECT_EQ(ids.front(), "foo");
+  EXPECT_EQ(constructed, 1);
+}
+
 TEST(EffectListConfigParser, ParsesMultipleEffects) {
   avs::EffectListEffect effect;
   int constructed = 0;


### PR DESCRIPTION
## Summary
- adjust effect list parser to leave array closing brackets for callers and consume them explicitly where needed
- add a regression test covering arrays that include whitespace around elements

## Testing
- ctest --test-dir build -R runtime_effect_list_parser_tests

------
https://chatgpt.com/codex/tasks/task_e_68f81f431cac832ca85b4cb9711adc2f