### PR TITLE
fix: normalize multiplier custom factors

### DIFF
--- a/src/effects/trans/effect_multiplier.cpp
+++ b/src/effects/trans/effect_multiplier.cpp
@@ -1,6 +1,7 @@
 #include "effects/trans/effect_multiplier.h"
 
 #include <algorithm>
+#include <array>
 #include <cmath>
 #include <cstddef>
 
@@ -43,25 +44,39 @@ void Multiplier::setParams(const avs::core::ParamBlock& params) {
   }
 
   bool customSpecified = false;
+  bool uniformSpecified = false;
+  const bool wasUsingCustom = useCustomFactors_;
+  std::array<bool, 3> channelSpecified{false, false, false};
   if (params.contains("factor")) {
     const float value = params.getFloat("factor", customFactors_[0]);
     customFactors_.fill(value);
     customSpecified = true;
+    uniformSpecified = true;
   }
   if (params.contains("factor_r")) {
     customFactors_[0] = params.getFloat("factor_r", customFactors_[0]);
     customSpecified = true;
+    channelSpecified[0] = true;
   }
   if (params.contains("factor_g")) {
     customFactors_[1] = params.getFloat("factor_g", customFactors_[1]);
     customSpecified = true;
+    channelSpecified[1] = true;
   }
   if (params.contains("factor_b")) {
     customFactors_[2] = params.getFloat("factor_b", customFactors_[2]);
     customSpecified = true;
+    channelSpecified[2] = true;
   }
 
   if (customSpecified) {
+    if (!uniformSpecified && !wasUsingCustom) {
+      for (std::size_t index = 0; index < channelSpecified.size(); ++index) {
+        if (!channelSpecified[index]) {
+          customFactors_[index] = 1.0f;
+        }
+      }
+    }
     useCustomFactors_ = true;
   } else if (modeSpecified) {
     useCustomFactors_ = false;

--- a/tests/core/test_trans_multiplier.cpp
+++ b/tests/core/test_trans_multiplier.cpp
@@ -101,3 +101,43 @@ TEST(TransMultiplierEffect, CustomFactorsOverrideMode) {
   EXPECT_EQ(pixels[3], 99u);
   EXPECT_EQ(pixels[7], 77u);
 }
+
+TEST(TransMultiplierEffect, SingleChannelDefaultsOthersToNeutral) {
+  avs::effects::trans::Multiplier effect;
+  avs::core::ParamBlock params;
+  params.setFloat("factor_r", 0.5f);
+  effect.setParams(params);
+
+  std::array<std::uint8_t, 8> pixels{100u, 50u, 10u, 0u, 20u, 40u, 80u, 0u};
+  auto context = makeContext(pixels);
+
+  ASSERT_TRUE(effect.render(context));
+  EXPECT_EQ(pixels[0], 50u);
+  EXPECT_EQ(pixels[1], 50u);
+  EXPECT_EQ(pixels[2], 10u);
+  EXPECT_EQ(pixels[4], 10u);
+  EXPECT_EQ(pixels[5], 40u);
+  EXPECT_EQ(pixels[6], 80u);
+}
+
+TEST(TransMultiplierEffect, ChannelOverrideRetainsPreviousUniformFactor) {
+  avs::effects::trans::Multiplier effect;
+  avs::core::ParamBlock params;
+  params.setFloat("factor", 1.5f);
+  effect.setParams(params);
+
+  avs::core::ParamBlock overrideParams;
+  overrideParams.setFloat("factor_r", 0.5f);
+  effect.setParams(overrideParams);
+
+  std::array<std::uint8_t, 8> pixels{100u, 80u, 60u, 0u, 40u, 20u, 10u, 0u};
+  auto context = makeContext(pixels);
+
+  ASSERT_TRUE(effect.render(context));
+  EXPECT_EQ(pixels[0], 50u);
+  EXPECT_EQ(pixels[1], 120u);
+  EXPECT_EQ(pixels[2], 90u);
+  EXPECT_EQ(pixels[4], 20u);
+  EXPECT_EQ(pixels[5], 30u);
+  EXPECT_EQ(pixels[6], 15u);
+}


### PR DESCRIPTION
## Summary
- ensure the multiplier effect normalizes unspecified custom channel factors when switching to custom mode
- add unit tests covering per-channel factor defaults and uniform-factor overrides

## Testing
- `ctest --test-dir build`


------
https://chatgpt.com/codex/tasks/task_e_68f81ead40cc832c921267d514f3c744