### PR TITLE
fix: align ColorClip integer color parsing with 0xRRGGBB

### DIFF
--- a/src/effects/trans/effect_color_clip.cpp
+++ b/src/effects/trans/effect_color_clip.cpp
@@ -15,7 +15,7 @@ std::uint8_t extractComponent(int value, int shift) {
 }
 
 int composeColor(const std::array<std::uint8_t, 3>& color) {
-  return static_cast<int>(color[0]) | (static_cast<int>(color[1]) << 8) | (static_cast<int>(color[2]) << 16);
+  return (static_cast<int>(color[0]) << 16) | (static_cast<int>(color[1]) << 8) | static_cast<int>(color[2]);
 }
 
 int readColorParam(const avs::core::ParamBlock& params, int fallback) {
@@ -50,9 +50,9 @@ void ColorClip::setParams(const avs::core::ParamBlock& params) {
   enabled_ = readEnabled(params, enabled_);
   const int defaultColor = composeColor(clipColor_);
   const int colorValue = readColorParam(params, defaultColor);
-  clipColor_[0] = extractComponent(colorValue, 0);
+  clipColor_[0] = extractComponent(colorValue, 16);
   clipColor_[1] = extractComponent(colorValue, 8);
-  clipColor_[2] = extractComponent(colorValue, 16);
+  clipColor_[2] = extractComponent(colorValue, 0);
 }
 
 bool ColorClip::render(avs::core::RenderContext& context) {


### PR DESCRIPTION
### Summary
Closes: N/A • Job: N/A
- decode `ColorClip` integer parameters using the standard 0xRRGGBB byte order.
- update default color encoding so preset fallbacks remain consistent with the corrected channel ordering.

### Checklist
- [x] Steps completed (map each step to a commit or note)
- [ ] Acceptance criteria satisfied
- [ ] Tests added/updated and passing (`ctest`)
- [ ] Warnings treated as errors (`-Werror`) clean
- [x] No binary blobs committed
- [ ] If binaries required for review, ZIP artifact attached (name: `binary-assets-<branch>.zip`)

### Notes
- Device/sample-rate notes (if audio): N/A
- Preset/parser fixtures updated: N/A

------
https://chatgpt.com/codex/tasks/task_e_68f8253db410832c98aaebb66abf7901