### PR TITLE
fix: preserve carry when averaging blend channels

### DIFF
--- a/libs/avs/effects/src/effects/blend_ops.cpp
+++ b/libs/avs/effects/src/effects/blend_ops.cpp
@@ -16,7 +16,8 @@ inline std::uint8_t saturatingAdd(std::uint8_t a, std::uint8_t b) {
 }
 
 inline std::uint8_t average(std::uint8_t a, std::uint8_t b) {
-  return static_cast<std::uint8_t>((a >> 1) + (b >> 1));
+  const std::uint16_t sum = static_cast<std::uint16_t>(a) + static_cast<std::uint16_t>(b);
+  return static_cast<std::uint8_t>(sum >> 1);
 }
 
 inline std::uint8_t blendTable(std::uint8_t value, std::uint8_t weight) {

--- a/src/effects/trans/effect_mosaic.cpp
+++ b/src/effects/trans/effect_mosaic.cpp
@@ -41,9 +41,15 @@ std::uint32_t Mosaic::blendAdditive(std::uint32_t dst, std::uint32_t src) {
 }
 
 std::uint32_t Mosaic::blendAverage(std::uint32_t dst, std::uint32_t src) {
-  const std::uint32_t lhs = (dst >> 1) & 0x7F7F7F7Fu;
-  const std::uint32_t rhs = (src >> 1) & 0x7F7F7F7Fu;
-  return lhs + rhs;
+  const std::uint16_t r = static_cast<std::uint16_t>(dst & 0xFFu) + static_cast<std::uint16_t>(src & 0xFFu);
+  const std::uint16_t g = static_cast<std::uint16_t>((dst >> 8) & 0xFFu) +
+                          static_cast<std::uint16_t>((src >> 8) & 0xFFu);
+  const std::uint16_t b = static_cast<std::uint16_t>((dst >> 16) & 0xFFu) +
+                          static_cast<std::uint16_t>((src >> 16) & 0xFFu);
+  const std::uint16_t a = static_cast<std::uint16_t>((dst >> 24) & 0xFFu) +
+                          static_cast<std::uint16_t>((src >> 24) & 0xFFu);
+  return static_cast<std::uint32_t>(r >> 1) | (static_cast<std::uint32_t>(g >> 1) << 8) |
+         (static_cast<std::uint32_t>(b >> 1) << 16) | (static_cast<std::uint32_t>(a >> 1) << 24);
 }
 
 void Mosaic::setParams(const avs::core::ParamBlock& params) {

--- a/tests/core/test_blend_ops.cpp
+++ b/tests/core/test_blend_ops.cpp
@@ -207,6 +207,19 @@ TEST(MicroPresetParser, KeepsHashPrefixedHexValues) {
   EXPECT_EQ(cmd.params.getInt("bg", 0), 0xff0000);
 }
 
+TEST(BlendOps, AverageBlendPreservesCarry) {
+  const avs::effects::BlendConfig config{};
+  const std::array<std::uint8_t, 4> dst{{255u, 1u, 3u, 5u}};
+  const std::array<std::uint8_t, 4> src{{255u, 3u, 1u, 7u}};
+
+  const auto result = avs::effects::blendPixel(avs::effects::BlendOp::Blend, config, dst, src);
+
+  EXPECT_EQ(result[0], 255u);
+  EXPECT_EQ(result[1], 2u);
+  EXPECT_EQ(result[2], 2u);
+  EXPECT_EQ(result[3], 6u);
+}
+
 class BlendEffectsTest : public ::testing::Test {
  protected:
   BlendEffectsTest() { avs::effects::registerCoreEffects(registry_); }


### PR DESCRIPTION
## Summary
- use 16-bit addition when averaging blend channels so the carry bit contributes to the result
- update the mosaic effect's average blend helper to apply the same per-channel averaging
- add a regression test that covers 50/50 blending of odd-valued channels

## Testing
- cmake .. -DCMAKE_BUILD_TYPE=Debug *(fails: missing PortAudio development package in container)*

------
https://chatgpt.com/codex/tasks/task_e_68f8255b47ac832c9f439c3a79b5b462