### PR TITLE
Fix dot plane color propagation and normalize color clip parsing

### DIFF
--- a/src/effects/render/effect_dot_plane.cpp
+++ b/src/effects/render/effect_dot_plane.cpp
@@ -219,10 +219,12 @@ void DotPlane::updateHeightField(const std::array<float, kGridSize>& previousTop
       const std::size_t src =
           static_cast<std::size_t>(row - 1) * kGridSize + static_cast<std::size_t>(column);
       float value = height_[src] + velocity_[src];
-      value = std::clamp(value, 0.0f, 255.0f);
-      height_[dst] = value;
+      if (value < 0.0f) {
+        value = 0.0f;
+      }
+      height_[dst] = std::min(value, 255.0f);
       velocity_[dst] = velocity_[src] - kDampingFactor * (value / 255.0f);
-      colorRows_[dst] = gradientColorForValue(value);
+      colorRows_[dst] = colorRows_[src];
     }
   }
 

--- a/src/effects/trans/effect_color_clip.cpp
+++ b/src/effects/trans/effect_color_clip.cpp
@@ -15,7 +15,8 @@ std::uint8_t extractComponent(int value, int shift) {
 }
 
 int composeColor(const std::array<std::uint8_t, 3>& color) {
-  return (static_cast<int>(color[0]) << 16) | (static_cast<int>(color[1]) << 8) | static_cast<int>(color[2]);
+  return static_cast<int>(color[0]) | (static_cast<int>(color[1]) << 8) |
+         (static_cast<int>(color[2]) << 16);
 }
 
 int readColorParam(const avs::core::ParamBlock& params, int fallback) {
@@ -50,9 +51,9 @@ void ColorClip::setParams(const avs::core::ParamBlock& params) {
   enabled_ = readEnabled(params, enabled_);
   const int defaultColor = composeColor(clipColor_);
   const int colorValue = readColorParam(params, defaultColor);
-  clipColor_[0] = extractComponent(colorValue, 16);
+  clipColor_[0] = extractComponent(colorValue, 0);
   clipColor_[1] = extractComponent(colorValue, 8);
-  clipColor_[2] = extractComponent(colorValue, 0);
+  clipColor_[2] = extractComponent(colorValue, 16);
 }
 
 bool ColorClip::render(avs::core::RenderContext& context) {


### PR DESCRIPTION
## Summary
- interpret color clip parameters using the channel ordering expected by the tests
- keep dot plane color rows aligned with the incoming audio-driven palette when advecting the height field

## Testing
- ctest --output-on-failure --test-dir build

------
https://chatgpt.com/codex/tasks/task_e_68f82bc79068832cb0950775d7d74dcf