### PR TITLE
Fix CI workflow environment reference

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,6 @@ on:
 env:
   CCACHE_DIR: ${{ github.workspace }}/.ccache
   CCACHE_MAXSIZE: 750M
-  CMAKE_BUILD_PARALLEL_LEVEL: ${{ steps.cores.outputs.cores }}
 
 jobs:
   build:


### PR DESCRIPTION
## Summary
- remove the workflow-level CMAKE_BUILD_PARALLEL_LEVEL entry that referenced a step output

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68f836cd1b40832c99a4b044ec50faa9