### PR TITLE
Fix CI YAML indentation for test sharding script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -324,46 +324,46 @@ jobs:
             ctest --test-dir build --output-on-failure --parallel "${CMAKE_BUILD_PARALLEL_LEVEL}"
             exit 0
           fi
-          python3 - <<'PY'
-import os
-import re
-import subprocess
-import sys
+            python3 - <<'PY'
+              import os
+              import re
+              import subprocess
+              import sys
 
-shard_index = int(os.environ["SHARD_INDEX"])
-shard_total = int(os.environ["SHARD_TOTAL"])
+              shard_index = int(os.environ["SHARD_INDEX"])
+              shard_total = int(os.environ["SHARD_TOTAL"])
 
-ctest_list = subprocess.check_output(["ctest", "--test-dir", "build", "-N"], text=True)
-tests = []
-for line in ctest_list.splitlines():
-    line = line.strip()
-    if line.startswith("Test #"):
-        parts = line.split(": ", 1)
-        if len(parts) == 2:
-            tests.append(parts[1].strip())
+              ctest_list = subprocess.check_output(["ctest", "--test-dir", "build", "-N"], text=True)
+              tests = []
+              for line in ctest_list.splitlines():
+                  line = line.strip()
+                  if line.startswith("Test #"):
+                      parts = line.split(": ", 1)
+                      if len(parts) == 2:
+                          tests.append(parts[1].strip())
 
-if not tests:
-    print("No tests discovered; exiting shard early.")
-    sys.exit(0)
+              if not tests:
+                  print("No tests discovered; exiting shard early.")
+                  sys.exit(0)
 
-tests.sort()
-shard_tests = tests[shard_index::shard_total]
+              tests.sort()
+              shard_tests = tests[shard_index::shard_total]
 
-if not shard_tests:
-    print("Shard has no tests to run; exiting.")
-    sys.exit(0)
+              if not shard_tests:
+                  print("Shard has no tests to run; exiting.")
+                  sys.exit(0)
 
-pattern = "^(%s)$" % "|".join(re.escape(t) for t in shard_tests)
-cmd = [
-    "ctest",
-    "--test-dir", "build",
-    "--output-on-failure",
-    "--parallel", os.environ.get("CMAKE_BUILD_PARALLEL_LEVEL", "1"),
-    "--tests-regex", pattern,
-]
+              pattern = "^(%s)$" % "|".join(re.escape(t) for t in shard_tests)
+              cmd = [
+                  "ctest",
+                  "--test-dir", "build",
+                  "--output-on-failure",
+                  "--parallel", os.environ.get("CMAKE_BUILD_PARALLEL_LEVEL", "1"),
+                  "--tests-regex", pattern,
+              ]
 
-print("Running:", " ".join(cmd))
-sys.stdout.flush()
-result = subprocess.call(cmd)
-sys.exit(result)
-PY
+              print("Running:", " ".join(cmd))
+              sys.stdout.flush()
+              result = subprocess.call(cmd)
+              sys.exit(result)
+            PY


### PR DESCRIPTION
## Summary
- indent the embedded Python script in the test job so the YAML parses correctly

## Testing
- not run (YAML-only change)


------
https://chatgpt.com/codex/tasks/task_e_68f83e20785c832cac145eb899b11c59