### PR TITLE
Fix CI shell compatibility for test shards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -315,6 +315,7 @@ jobs:
           path: .
 
       - name: Run tests
+        shell: bash
         env:
           SHARD_INDEX: ${{ matrix.shard }}
           SHARD_TOTAL: ${{ matrix.total_shards }}
@@ -324,46 +325,46 @@ jobs:
             ctest --test-dir build --output-on-failure --parallel "${CMAKE_BUILD_PARALLEL_LEVEL}"
             exit 0
           fi
-            python3 - <<'PY'
-              import os
-              import re
-              import subprocess
-              import sys
+          python3 - <<'PY'
+import os
+import re
+import subprocess
+import sys
 
-              shard_index = int(os.environ["SHARD_INDEX"])
-              shard_total = int(os.environ["SHARD_TOTAL"])
+shard_index = int(os.environ["SHARD_INDEX"])
+shard_total = int(os.environ["SHARD_TOTAL"])
 
-              ctest_list = subprocess.check_output(["ctest", "--test-dir", "build", "-N"], text=True)
-              tests = []
-              for line in ctest_list.splitlines():
-                  line = line.strip()
-                  if line.startswith("Test #"):
-                      parts = line.split(": ", 1)
-                      if len(parts) == 2:
-                          tests.append(parts[1].strip())
+ctest_list = subprocess.check_output(["ctest", "--test-dir", "build", "-N"], text=True)
+tests = []
+for line in ctest_list.splitlines():
+    line = line.strip()
+    if line.startswith("Test #"):
+        parts = line.split(": ", 1)
+        if len(parts) == 2:
+            tests.append(parts[1].strip())
 
-              if not tests:
-                  print("No tests discovered; exiting shard early.")
-                  sys.exit(0)
+if not tests:
+    print("No tests discovered; exiting shard early.")
+    sys.exit(0)
 
-              tests.sort()
-              shard_tests = tests[shard_index::shard_total]
+tests.sort()
+shard_tests = tests[shard_index::shard_total]
 
-              if not shard_tests:
-                  print("Shard has no tests to run; exiting.")
-                  sys.exit(0)
+if not shard_tests:
+    print("Shard has no tests to run; exiting.")
+    sys.exit(0)
 
-              pattern = "^(%s)$" % "|".join(re.escape(t) for t in shard_tests)
-              cmd = [
-                  "ctest",
-                  "--test-dir", "build",
-                  "--output-on-failure",
-                  "--parallel", os.environ.get("CMAKE_BUILD_PARALLEL_LEVEL", "1"),
-                  "--tests-regex", pattern,
-              ]
+pattern = "^(%s)$" % "|".join(re.escape(t) for t in shard_tests)
+cmd = [
+    "ctest",
+    "--test-dir", "build",
+    "--output-on-failure",
+    "--parallel", os.environ.get("CMAKE_BUILD_PARALLEL_LEVEL", "1"),
+    "--tests-regex", pattern,
+]
 
-              print("Running:", " ".join(cmd))
-              sys.stdout.flush()
-              result = subprocess.call(cmd)
-              sys.exit(result)
-            PY
+print("Running:", " ".join(cmd))
+sys.stdout.flush()
+result = subprocess.call(cmd)
+sys.exit(result)
+PY


### PR DESCRIPTION
## Summary
- ensure the test shard runner executes under bash so `set -euo pipefail` is available
- remove unintended indentation in the inline Python sharding script to avoid runtime syntax errors

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_68f8403af17c832c92fab7f9d14d6675