### PR TITLE
Fix YAML syntax in CI workflow

### DIFF
--- a/.github/scripts/run_sharded_ctest.py
+++ b/.github/scripts/run_sharded_ctest.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Utility to shard ctest execution for GitHub Actions."""
+
+import os
+import re
+import subprocess
+import sys
+
+
+def discover_tests() -> list[str]:
+    """Return the sorted list of discovered ctest names."""
+    ctest_list = subprocess.check_output(
+        ["ctest", "--test-dir", "build", "-N"], text=True
+    )
+    tests: list[str] = []
+    for line in ctest_list.splitlines():
+        line = line.strip()
+        if line.startswith("Test #"):
+            parts = line.split(": ", 1)
+            if len(parts) == 2:
+                tests.append(parts[1].strip())
+    tests.sort()
+    return tests
+
+
+def shard_tests(tests: list[str], shard_index: int, shard_total: int) -> list[str]:
+    """Select the subset of tests that belong to the shard."""
+    return tests[shard_index::shard_total]
+
+
+def run_sharded_ctest() -> int:
+    shard_index = int(os.environ["SHARD_INDEX"])
+    shard_total = int(os.environ["SHARD_TOTAL"])
+
+    tests = discover_tests()
+    if not tests:
+        print("No tests discovered; exiting shard early.")
+        return 0
+
+    shard_selection = shard_tests(tests, shard_index, shard_total)
+    if not shard_selection:
+        print("Shard has no tests to run; exiting.")
+        return 0
+
+    pattern = "^(%s)$" % "|".join(re.escape(test) for test in shard_selection)
+    cmd = [
+        "ctest",
+        "--test-dir",
+        "build",
+        "--output-on-failure",
+        "--parallel",
+        os.environ.get("CMAKE_BUILD_PARALLEL_LEVEL", "1"),
+        "--tests-regex",
+        pattern,
+    ]
+
+    print("Running:", " ".join(cmd))
+    sys.stdout.flush()
+    return subprocess.call(cmd)
+
+
+if __name__ == "__main__":
+    sys.exit(run_sharded_ctest())

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -325,46 +325,4 @@ jobs:
             ctest --test-dir build --output-on-failure --parallel "${CMAKE_BUILD_PARALLEL_LEVEL}"
             exit 0
           fi
-          python3 - <<'PY'
-import os
-import re
-import subprocess
-import sys
-
-shard_index = int(os.environ["SHARD_INDEX"])
-shard_total = int(os.environ["SHARD_TOTAL"])
-
-ctest_list = subprocess.check_output(["ctest", "--test-dir", "build", "-N"], text=True)
-tests = []
-for line in ctest_list.splitlines():
-    line = line.strip()
-    if line.startswith("Test #"):
-        parts = line.split(": ", 1)
-        if len(parts) == 2:
-            tests.append(parts[1].strip())
-
-if not tests:
-    print("No tests discovered; exiting shard early.")
-    sys.exit(0)
-
-tests.sort()
-shard_tests = tests[shard_index::shard_total]
-
-if not shard_tests:
-    print("Shard has no tests to run; exiting.")
-    sys.exit(0)
-
-pattern = "^(%s)$" % "|".join(re.escape(t) for t in shard_tests)
-cmd = [
-    "ctest",
-    "--test-dir", "build",
-    "--output-on-failure",
-    "--parallel", os.environ.get("CMAKE_BUILD_PARALLEL_LEVEL", "1"),
-    "--tests-regex", pattern,
-]
-
-print("Running:", " ".join(cmd))
-sys.stdout.flush()
-result = subprocess.call(cmd)
-sys.exit(result)
-PY
+          python3 .github/scripts/run_sharded_ctest.py


### PR DESCRIPTION
## Summary
- move the sharded ctest helper into `.github/scripts/run_sharded_ctest.py`
- update the CI workflow to call the helper script directly, restoring valid YAML syntax

## Testing
- `python3 - <<'PY'
import yaml
with open('vis_avs/.github/workflows/ci.yml') as f:
    yaml.safe_load(f)
print('ok')
PY`

------
https://chatgpt.com/codex/tasks/task_e_68f8419d13b4832cabbdcc92a33454c0