### PR TITLE
Fix CI test job build directory detection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -314,6 +314,31 @@ jobs:
           name: build-${{ matrix.distro }}
           path: .
 
+      - name: Normalize build directory
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ -d build ]; then
+            exit 0
+          fi
+
+          distro_dir="build-${{ matrix.distro }}"
+          if [ -d "${distro_dir}/build" ]; then
+            mv "${distro_dir}/build" build
+            rmdir "${distro_dir}" || true
+            exit 0
+          fi
+
+          if [ -d "${distro_dir}" ]; then
+            mv "${distro_dir}" build
+            exit 0
+          fi
+
+          echo "Unable to locate build directory after downloading artifact" >&2
+          echo "Contents of workspace:" >&2
+          ls -al >&2
+          exit 1
+
       - name: Run tests
         shell: bash
         env:


### PR DESCRIPTION
## Summary
- ensure the tests job normalizes the downloaded build artifact into the expected `build` directory
- add defensive diagnostics when the build directory cannot be located

## Testing
- not run (CI workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68f84461f65c832c8a3809d56b6b96f9