### PR TITLE
Fix sharded ctest script to auto-detect build directory

### DIFF
--- a/.github/scripts/run_sharded_ctest.py
+++ b/.github/scripts/run_sharded_ctest.py
@@ -7,10 +7,41 @@ import subprocess
 import sys
 
 
-def discover_tests() -> list[str]:
+def resolve_build_dir() -> str:
+    """Return the path to the CTest binary directory."""
+    env_dir = os.environ.get("CTEST_BINARY_DIRECTORY")
+    if env_dir:
+        if os.path.isdir(env_dir):
+            return env_dir
+        raise FileNotFoundError(f"Configured CTest directory '{env_dir}' does not exist")
+
+    default_dir = "build"
+    if os.path.isdir(default_dir):
+        return default_dir
+
+    # Fall back to scanning for a directory that contains CTest metadata.
+    for entry in os.scandir("."):
+        if not entry.is_dir():
+            continue
+        candidate = entry.path
+        ctest_file = os.path.join(candidate, "CTestTestfile.cmake")
+        if os.path.isfile(ctest_file):
+            return candidate
+        nested_candidate = os.path.join(candidate, "build")
+        nested_ctest_file = os.path.join(nested_candidate, "CTestTestfile.cmake")
+        if os.path.isfile(nested_ctest_file):
+            return nested_candidate
+
+    raise FileNotFoundError(
+        "Unable to locate a CTest binary directory. Ensure the build artifact "
+        "is downloaded and extracted into the workspace."
+    )
+
+
+def discover_tests(build_dir: str) -> list[str]:
     """Return the sorted list of discovered ctest names."""
     ctest_list = subprocess.check_output(
-        ["ctest", "--test-dir", "build", "-N"], text=True
+        ["ctest", "--test-dir", build_dir, "-N"], text=True
     )
     tests: list[str] = []
     for line in ctest_list.splitlines():
@@ -32,7 +63,13 @@ def run_sharded_ctest() -> int:
     shard_index = int(os.environ["SHARD_INDEX"])
     shard_total = int(os.environ["SHARD_TOTAL"])
 
-    tests = discover_tests()
+    try:
+        build_dir = resolve_build_dir()
+    except FileNotFoundError as exc:  # pragma: no cover - informative failure path
+        print(str(exc), file=sys.stderr)
+        return 1
+
+    tests = discover_tests(build_dir)
     if not tests:
         print("No tests discovered; exiting shard early.")
         return 0
@@ -46,7 +83,7 @@ def run_sharded_ctest() -> int:
     cmd = [
         "ctest",
         "--test-dir",
-        "build",
+        build_dir,
         "--output-on-failure",
         "--parallel",
         os.environ.get("CMAKE_BUILD_PARALLEL_LEVEL", "1"),


### PR DESCRIPTION
## Summary
- add build directory discovery to the sharded ctest helper so CI shards succeed even when the build tree is unpacked elsewhere
- allow overriding the build path through `CTEST_BINARY_DIRECTORY` and emit actionable errors when it cannot be found

## Testing
- python3 -m compileall .github/scripts/run_sharded_ctest.py


------
https://chatgpt.com/codex/tasks/task_e_68f84461f65c832c8a3809d56b6b96f9