### PR TITLE
Fix CI build artifact extraction

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -323,6 +323,63 @@ jobs:
           fi
 
           distro_dir="build-${{ matrix.distro }}"
+
+          maybe_extract_archive() {
+            local archive="$1"
+            local tmpdir
+
+            if [ ! -f "${archive}" ]; then
+              return 1
+            fi
+
+            tmpdir="$(mktemp -d)"
+            trap 'rm -rf "${tmpdir}"' RETURN
+
+            case "${archive}" in
+              *.tar.gz|*.tgz)
+                tar -xzf "${archive}" -C "${tmpdir}"
+                ;;
+              *.tar)
+                tar -xf "${archive}" -C "${tmpdir}"
+                ;;
+              *.zip)
+                python3 - "${archive}" "${tmpdir}" <<'PY'
+import sys
+import zipfile
+from pathlib import Path
+
+archive_path = Path(sys.argv[1])
+destination = Path(sys.argv[2])
+
+with zipfile.ZipFile(archive_path) as zf:
+    zf.extractall(destination)
+PY
+                ;;
+              *)
+                echo "Unsupported archive format: ${archive}" >&2
+                return 1
+                ;;
+            esac
+
+            if [ -d "${tmpdir}/build" ]; then
+              mv "${tmpdir}/build" build
+            else
+              local first_dir
+              first_dir="$(find "${tmpdir}" -mindepth 1 -maxdepth 1 -type d | head -n 1)"
+              if [ -n "${first_dir}" ]; then
+                mv "${first_dir}" build
+              else
+                echo "Archive ${archive} did not contain a build directory" >&2
+                return 1
+              fi
+            fi
+
+            rm -rf "${tmpdir}"
+            rm -f "${archive}"
+            trap - RETURN
+            return 0
+          }
+
           if [ -d "${distro_dir}/build" ]; then
             mv "${distro_dir}/build" build
             rmdir "${distro_dir}" || true
@@ -333,6 +390,17 @@ jobs:
             mv "${distro_dir}" build
             exit 0
           fi
+
+          for archive in \
+            "${distro_dir}.tar.gz" \
+            "${distro_dir}.tgz" \
+            "${distro_dir}.tar" \
+            "${distro_dir}.zip"
+          do
+            if maybe_extract_archive "${archive}"; then
+              exit 0
+            fi
+          done
 
           echo "Unable to locate build directory after downloading artifact" >&2
           echo "Contents of workspace:" >&2


### PR DESCRIPTION
## Summary
- teach the tests job to unpack build artifacts compressed as tarballs or zip files before running ctest

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68f849bfd1ec832c902a83e31c42e8ec