### PR TITLE
fix: terminate case statement in build prep script

### DIFF
--- a/.github/scripts/prepare_build_directories.sh
+++ b/.github/scripts/prepare_build_directories.sh
@@ -23,4 +23,4 @@ case "${DISTRO}" in
     echo "Unsupported distro: ${DISTRO}" >&2
     exit 1
     ;;
-fi
+esac


### PR DESCRIPTION
## Summary
- replace the incorrect `fi` terminator at the end of the distro switch with `esac`
- ensure the build preparation script runs correctly for Fedora

## Testing
- DISTRO=fedora bash .github/scripts/prepare_build_directories.sh

------
https://chatgpt.com/codex/tasks/task_e_68f84e25ce14832ca9066c6c362cdf96