### PR TITLE
Fix distro case endings in CI setup scripts

### DIFF
--- a/.github/scripts/install_build_dependencies.sh
+++ b/.github/scripts/install_build_dependencies.sh
@@ -56,4 +56,4 @@ case "${DISTRO}" in
     echo "Unsupported distro: ${DISTRO}" >&2
     exit 1
     ;;
-fi
+esac

--- a/.github/scripts/install_runtime_dependencies.sh
+++ b/.github/scripts/install_runtime_dependencies.sh
@@ -44,4 +44,4 @@ case "${DISTRO}" in
     echo "Unsupported distro: ${DISTRO}" >&2
     exit 1
     ;;
-fi
+esac

--- a/.github/scripts/prepare_test_directories.sh
+++ b/.github/scripts/prepare_test_directories.sh
@@ -22,4 +22,4 @@ case "${DISTRO}" in
     echo "Unsupported distro: ${DISTRO}" >&2
     exit 1
     ;;
-fi
+esac


### PR DESCRIPTION
## Summary
- replace the stray `fi` tokens with the correct `esac` terminators in the distro selection logic used by CI helper scripts
- ensure the build, runtime, and test setup scripts now exit cleanly so that the workflow can finish its build and test stages

## Testing
- `DISTRO=ubuntu bash .github/scripts/install_build_dependencies.sh`
- `DISTRO=ubuntu bash .github/scripts/install_runtime_dependencies.sh`
- `GITHUB_WORKSPACE=$PWD DISTRO=ubuntu bash .github/scripts/prepare_test_directories.sh`
- `cmake --build build -- -k 0`
- `SHARD_INDEX=0 SHARD_TOTAL=1 CMAKE_BUILD_PARALLEL_LEVEL=4 bash .github/scripts/run_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68f84f2b46c8832cafdbb6e3a91aa0cd