### PR TITLE
Fix test jobs artifact extraction path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,7 +211,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: build-${{ matrix.distro }}
-          path: .
+          path: build-${{ matrix.distro }}
 
       - name: Normalize build directory
         shell: bash


### PR DESCRIPTION
## Summary
- download build artifacts into a distro-specific directory so the normalize script can promote it to `build`

## Testing
- not run (CI will cover)

------
https://chatgpt.com/codex/tasks/task_e_68f853ee7e4c832c9adf8d3fa024daf3