### PR TITLE
Fix test runner to restore executable permissions

### DIFF
--- a/.github/scripts/run_tests.sh
+++ b/.github/scripts/run_tests.sh
@@ -5,6 +5,17 @@ SHARD_INDEX="${SHARD_INDEX:-0}"
 SHARD_TOTAL="${SHARD_TOTAL:-1}"
 CMAKE_BUILD_PARALLEL_LEVEL="${CMAKE_BUILD_PARALLEL_LEVEL:-1}"
 
+ensure_test_binaries_are_executable() {
+  local candidate
+  for candidate in "build/tests" "build/tools"; do
+    if [[ -d "${candidate}" ]]; then
+      find "${candidate}" -type f -print0 | xargs -0 -r chmod +x
+    fi
+  done
+}
+
+ensure_test_binaries_are_executable
+
 if [[ "${SHARD_TOTAL}" -le 1 ]]; then
   ctest --test-dir build --output-on-failure --parallel "${CMAKE_BUILD_PARALLEL_LEVEL}"
   exit 0


### PR DESCRIPTION
### Summary
Closes: N/A • Job: N/A

- ensure the shared test runner restores executable permissions on extracted binaries so ctest can launch them.

### Checklist
- [x] Steps completed (map each step to a commit or note)
- [x] Acceptance criteria satisfied
- [ ] Tests added/updated and passing (`ctest`)
- [x] Warnings treated as errors (`-Werror`) clean
- [x] No binary blobs committed
- [x] If binaries required for review, ZIP artifact attached (name: `binary-assets-<branch>.zip`)

### Notes
- Device/sample-rate notes (if audio): N/A
- Preset/parser fixtures updated: N/A

------
https://chatgpt.com/codex/tasks/task_e_68f8558b73c8832c8e89837e7c4a39ed