### PR TITLE
Add audio-driven timescope render effect

### DIFF
--- a/libs/avs/effects/CMakeLists.txt
+++ b/libs/avs/effects/CMakeLists.txt
@@ -6,7 +6,6 @@ set(AVS_EFFECT_STUB_SOURCES
   ${CMAKE_SOURCE_DIR}/src/effects/stubs/effect_render_simple.cpp
   ${CMAKE_SOURCE_DIR}/src/effects/stubs/effect_render_avi.cpp
   ${CMAKE_SOURCE_DIR}/src/effects/stubs/effect_render_svp_loader.cpp
-  ${CMAKE_SOURCE_DIR}/src/effects/stubs/effect_render_timescope.cpp
   ${CMAKE_SOURCE_DIR}/src/effects/stubs/effect_trans_brightness.cpp
   ${CMAKE_SOURCE_DIR}/src/effects/stubs/effect_trans_color_clip.cpp
   ${CMAKE_SOURCE_DIR}/src/effects/stubs/effect_trans_color_modifier.cpp
@@ -74,6 +73,7 @@ add_library(avs-effects-core
   ${CMAKE_SOURCE_DIR}/src/effects/render/effect_rotating_stars.cpp
   ${CMAKE_SOURCE_DIR}/src/effects/render/effect_dot_plane.cpp
   ${CMAKE_SOURCE_DIR}/src/effects/render/effect_dot_fountain.cpp
+  ${CMAKE_SOURCE_DIR}/src/effects/render/effect_timescope.cpp
   ${CMAKE_SOURCE_DIR}/src/effects/misc/effect_render_mode.cpp
   ${CMAKE_SOURCE_DIR}/src/effects/misc/effect_custom_bpm.cpp
   ${CMAKE_SOURCE_DIR}/src/effects/trans/effect_multiplier.cpp

--- a/libs/avs/effects/src/RegisterEffects.cpp
+++ b/libs/avs/effects/src/RegisterEffects.cpp
@@ -47,7 +47,7 @@
 #include "effects/render/effect_ring.h"
 #include "effects/stubs/effect_render_simple.h"
 #include "effects/stubs/effect_render_svp_loader.h"
-#include "effects/stubs/effect_render_timescope.h"
+#include "effects/render/effect_timescope.h"
 #include "effects/trans/effect_color_clip.h"
 #include "effects/trans/effect_brightness.h"
 #include "effects/trans/effect_blur.h"
@@ -143,8 +143,8 @@ void registerCoreEffects(avs::core::EffectRegistry& registry) {
   registry.registerFactory("render / simple", []() { return std::make_unique<Effect_RenderSimple>(); });
   registry.registerFactory("Render / SVP Loader", []() { return std::make_unique<Effect_RenderSvpLoader>(); });
   registry.registerFactory("render / svp loader", []() { return std::make_unique<Effect_RenderSvpLoader>(); });
-  registry.registerFactory("Render / Timescope", []() { return std::make_unique<Effect_RenderTimescope>(); });
-  registry.registerFactory("render / timescope", []() { return std::make_unique<Effect_RenderTimescope>(); });
+  registry.registerFactory("Render / Timescope", []() { return std::make_unique<render::Timescope>(); });
+  registry.registerFactory("render / timescope", []() { return std::make_unique<render::Timescope>(); });
   registry.registerFactory("Trans / Blitter Feedback", []() { return std::make_unique<trans::BlitterFeedback>(); });
   registry.registerFactory("trans / blitter feedback", []() { return std::make_unique<trans::BlitterFeedback>(); });
   registry.registerFactory("Filter / Blur", []() { return std::make_unique<filters::BlurBox>(); });

--- a/src/effects/render/effect_timescope.cpp
+++ b/src/effects/render/effect_timescope.cpp
@@ -1,0 +1,234 @@
+#include "effects/render/effect_timescope.h"
+
+#include <algorithm>
+#include <cctype>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <string_view>
+
+#include "audio/analyzer.h"
+
+namespace avs::effects::render {
+
+namespace {
+constexpr int kMaxBands = static_cast<int>(avs::audio::Analysis::kWaveformSize);
+}
+
+Timescope::Timescope() = default;
+
+std::uint8_t Timescope::clampByte(int value) {
+  if (value < 0) {
+    return 0u;
+  }
+  if (value > 255) {
+    return 255u;
+  }
+  return static_cast<std::uint8_t>(value);
+}
+
+std::uint8_t Timescope::saturatingAdd(std::uint8_t a, std::uint8_t b) {
+  const int sum = static_cast<int>(a) + static_cast<int>(b);
+  return static_cast<std::uint8_t>(sum > 255 ? 255 : sum);
+}
+
+Timescope::Color Timescope::decodeColor(std::uint32_t value) {
+  Color color{};
+  color.r = static_cast<std::uint8_t>((value >> 16u) & 0xFFu);
+  color.g = static_cast<std::uint8_t>((value >> 8u) & 0xFFu);
+  color.b = static_cast<std::uint8_t>(value & 0xFFu);
+  return color;
+}
+
+std::uint32_t Timescope::encodeColor(const Color& color) {
+  return static_cast<std::uint32_t>(color.r) << 16u | static_cast<std::uint32_t>(color.g) << 8u |
+         static_cast<std::uint32_t>(color.b);
+}
+
+std::uint8_t Timescope::intensityFromSample(float sample) {
+  const float clamped = std::clamp(sample, -1.0f, 1.0f);
+  const float scaled = (clamped + 1.0f) * 127.5f;
+  const int value = static_cast<int>(std::lround(scaled));
+  return clampByte(value);
+}
+
+std::string Timescope::toLower(std::string_view value) {
+  std::string result(value);
+  std::transform(result.begin(), result.end(), result.begin(),
+                 [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+  return result;
+}
+
+void Timescope::resetState() {
+  column_ = -1;
+  lastWidth_ = 0;
+}
+
+void Timescope::applyBlend(std::uint8_t* pixel, const Rgba& src) const {
+  switch (blendMode_) {
+    case BlendMode::Replace: {
+      pixel[0] = src.r;
+      pixel[1] = src.g;
+      pixel[2] = src.b;
+      pixel[3] = 255u;
+      break;
+    }
+    case BlendMode::Additive: {
+      pixel[0] = saturatingAdd(pixel[0], src.r);
+      pixel[1] = saturatingAdd(pixel[1], src.g);
+      pixel[2] = saturatingAdd(pixel[2], src.b);
+      pixel[3] = std::max(pixel[3], src.a);
+      break;
+    }
+    case BlendMode::Average: {
+      pixel[0] = static_cast<std::uint8_t>((static_cast<int>(pixel[0]) + src.r) / 2);
+      pixel[1] = static_cast<std::uint8_t>((static_cast<int>(pixel[1]) + src.g) / 2);
+      pixel[2] = static_cast<std::uint8_t>((static_cast<int>(pixel[2]) + src.b) / 2);
+      pixel[3] = std::max(pixel[3], src.a);
+      break;
+    }
+    case BlendMode::Alpha: {
+      const std::uint8_t alpha = src.a;
+      const std::uint8_t inv = static_cast<std::uint8_t>(255u - alpha);
+      pixel[0] = static_cast<std::uint8_t>(
+          (static_cast<int>(pixel[0]) * inv + static_cast<int>(src.r) * alpha) / 255);
+      pixel[1] = static_cast<std::uint8_t>(
+          (static_cast<int>(pixel[1]) * inv + static_cast<int>(src.g) * alpha) / 255);
+      pixel[2] = static_cast<std::uint8_t>(
+          (static_cast<int>(pixel[2]) * inv + static_cast<int>(src.b) * alpha) / 255);
+      pixel[3] = std::max(pixel[3], alpha);
+      break;
+    }
+  }
+}
+
+Timescope::Rgba Timescope::colorForIntensity(std::uint8_t intensity) const {
+  Rgba color{};
+  color.r = static_cast<std::uint8_t>((static_cast<int>(color_.r) * intensity) / 255);
+  color.g = static_cast<std::uint8_t>((static_cast<int>(color_.g) * intensity) / 255);
+  color.b = static_cast<std::uint8_t>((static_cast<int>(color_.b) * intensity) / 255);
+  color.a = intensity;
+  return color;
+}
+
+Timescope::SampleView Timescope::resolveWaveform(const avs::core::RenderContext& context) const {
+  if (context.audioAnalysis) {
+    const auto* analysis = context.audioAnalysis;
+    return {analysis->waveform.data(), analysis->waveform.size()};
+  }
+  return {};
+}
+
+std::size_t Timescope::sampleIndexForRow(int row, int height, std::size_t available) const {
+  if (height <= 0 || available == 0) {
+    return 0;
+  }
+  const int effectiveBands = std::clamp(bands_, 1, static_cast<int>(available));
+  const long long scaled = static_cast<long long>(row) * static_cast<long long>(effectiveBands);
+  int index = static_cast<int>(scaled / static_cast<long long>(height));
+  if (index < 0) {
+    index = 0;
+  }
+  if (index >= effectiveBands) {
+    index = effectiveBands - 1;
+  }
+  return static_cast<std::size_t>(index);
+}
+
+void Timescope::setParams(const avs::core::ParamBlock& params) {
+  if (params.contains("enabled")) {
+    enabled_ = params.getBool("enabled", enabled_);
+  }
+
+  if (params.contains("color")) {
+    color_ = decodeColor(
+        static_cast<std::uint32_t>(params.getInt("color", static_cast<int>(encodeColor(color_)))));
+  }
+  if (params.contains("color_r")) {
+    color_.r = clampByte(params.getInt("color_r", color_.r));
+  }
+  if (params.contains("color_g")) {
+    color_.g = clampByte(params.getInt("color_g", color_.g));
+  }
+  if (params.contains("color_b")) {
+    color_.b = clampByte(params.getInt("color_b", color_.b));
+  }
+
+  if (params.contains("blend_mode")) {
+    const std::string value = toLower(params.getString("blend_mode", "alpha"));
+    if (value == "replace") {
+      blendMode_ = BlendMode::Replace;
+    } else if (value == "add" || value == "additive") {
+      blendMode_ = BlendMode::Additive;
+    } else if (value == "avg" || value == "average") {
+      blendMode_ = BlendMode::Average;
+    } else {
+      blendMode_ = BlendMode::Alpha;
+    }
+  } else if (params.contains("blend") || params.contains("blendavg")) {
+    const int blendInt = params.getInt("blend", 0);
+    const bool blendAvg = params.getBool("blendavg", false);
+    if (blendInt == 1) {
+      blendMode_ = BlendMode::Additive;
+    } else if (blendInt == 2) {
+      blendMode_ = BlendMode::Alpha;
+    } else if (blendAvg) {
+      blendMode_ = BlendMode::Average;
+    } else {
+      blendMode_ = BlendMode::Replace;
+    }
+  }
+
+  if (params.contains("bands")) {
+    bands_ = std::clamp(params.getInt("bands", bands_), 1, kMaxBands);
+  } else if (params.contains("nbands")) {
+    bands_ = std::clamp(params.getInt("nbands", bands_), 1, kMaxBands);
+  }
+
+  resetState();
+}
+
+bool Timescope::render(avs::core::RenderContext& context) {
+  if (!enabled_) {
+    return true;
+  }
+  if (!context.framebuffer.data || context.width <= 0 || context.height <= 0) {
+    return true;
+  }
+
+  const std::size_t required =
+      static_cast<std::size_t>(context.width) * static_cast<std::size_t>(context.height) * 4u;
+  if (context.framebuffer.size < required) {
+    return false;
+  }
+
+  SampleView waveform = resolveWaveform(context);
+  if (!waveform.data || waveform.size == 0) {
+    return true;
+  }
+
+  if (context.width != lastWidth_) {
+    column_ = -1;
+    lastWidth_ = context.width;
+  }
+  column_ = (column_ + 1) % context.width;
+
+  for (int y = 0; y < context.height; ++y) {
+    const std::size_t sampleIndex = sampleIndexForRow(y, context.height, waveform.size);
+    const float sample = waveform.data[sampleIndex];
+    const std::uint8_t intensity = intensityFromSample(sample);
+    const Rgba color = colorForIntensity(intensity);
+
+    const std::size_t offset =
+        (static_cast<std::size_t>(y) * static_cast<std::size_t>(context.width) +
+         static_cast<std::size_t>(column_)) *
+        4u;
+    std::uint8_t* pixel = context.framebuffer.data + offset;
+    applyBlend(pixel, color);
+  }
+
+  return true;
+}
+
+}  // namespace avs::effects::render

--- a/src/effects/render/effect_timescope.h
+++ b/src/effects/render/effect_timescope.h
@@ -1,0 +1,72 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <string_view>
+
+#include "avs/core/IEffect.hpp"
+#include "avs/core/ParamBlock.hpp"
+#include "avs/core/RenderContext.hpp"
+
+namespace avs::effects::render {
+
+/**
+ * @brief Scrolling visualization of the audio waveform.
+ */
+class Timescope : public avs::core::IEffect {
+ public:
+  Timescope();
+  ~Timescope() override = default;
+
+  void setParams(const avs::core::ParamBlock& params) override;
+  bool render(avs::core::RenderContext& context) override;
+
+ private:
+  enum class BlendMode {
+    Replace,
+    Additive,
+    Average,
+    Alpha,
+  };
+
+  struct Color {
+    std::uint8_t r = 255;
+    std::uint8_t g = 255;
+    std::uint8_t b = 255;
+  };
+
+  struct Rgba {
+    std::uint8_t r = 0;
+    std::uint8_t g = 0;
+    std::uint8_t b = 0;
+    std::uint8_t a = 255;
+  };
+
+  struct SampleView {
+    const float* data = nullptr;
+    std::size_t size = 0;
+  };
+
+  static std::uint8_t clampByte(int value);
+  static std::uint8_t saturatingAdd(std::uint8_t a, std::uint8_t b);
+  static Color decodeColor(std::uint32_t value);
+  static std::uint32_t encodeColor(const Color& color);
+  static std::uint8_t intensityFromSample(float sample);
+  static std::string toLower(std::string_view value);
+
+  void resetState();
+  void applyBlend(std::uint8_t* pixel, const Rgba& src) const;
+  Rgba colorForIntensity(std::uint8_t intensity) const;
+  SampleView resolveWaveform(const avs::core::RenderContext& context) const;
+  std::size_t sampleIndexForRow(int row, int height, std::size_t available) const;
+
+  bool enabled_ = true;
+  Color color_{};
+  BlendMode blendMode_ = BlendMode::Alpha;
+  int bands_ = 576;
+  int column_ = -1;
+  int lastWidth_ = 0;
+};
+
+}  // namespace avs::effects::render

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -67,6 +67,7 @@ add_executable(core_effects_tests
   core/test_colorfade.cpp
   core/test_rotating_stars.cpp
   core/test_render_ring.cpp
+  core/test_render_timescope.cpp
   core/test_render_dot_fountain.cpp
   core/test_render_mode.cpp
   core/test_misc_comment.cpp

--- a/tests/core/test_render_timescope.cpp
+++ b/tests/core/test_render_timescope.cpp
@@ -1,0 +1,89 @@
+#include <gtest/gtest.h>
+
+#include <array>
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <string>
+#include <vector>
+
+#include "audio/analyzer.h"
+#include "avs/core/ParamBlock.hpp"
+#include "avs/core/RenderContext.hpp"
+#include "effects/render/effect_timescope.h"
+
+namespace {
+
+std::string hashFNV1a(const std::vector<std::uint8_t>& data) {
+  constexpr std::uint32_t kPrime = 16777619u;
+  std::uint32_t hash = 2166136261u;
+  for (std::uint8_t byte : data) {
+    hash ^= byte;
+    hash *= kPrime;
+  }
+  std::array<char, 9> buffer{};
+  std::snprintf(buffer.data(), buffer.size(), "%08x", hash);
+  return std::string(buffer.data());
+}
+
+avs::audio::Analysis makeAnalysis() {
+  avs::audio::Analysis analysis;
+  for (std::size_t i = 0; i < analysis.waveform.size(); ++i) {
+    const float t = static_cast<float>(i) / static_cast<float>(analysis.waveform.size() - 1);
+    analysis.waveform[i] = std::sin(t * 6.2831853f);
+  }
+  return analysis;
+}
+
+avs::core::RenderContext makeContext(int width, int height, std::vector<std::uint8_t>& pixels,
+                                     avs::audio::Analysis& analysis) {
+  avs::core::RenderContext context;
+  context.width = width;
+  context.height = height;
+  context.frameIndex = 0;
+  context.deltaSeconds = 1.0 / 60.0;
+  context.framebuffer = {pixels.data(), pixels.size()};
+  context.audioAnalysis = &analysis;
+  return context;
+}
+
+}  // namespace
+
+TEST(RenderTimescopeTest, AlphaBlendProducesStableHash) {
+  avs::effects::render::Timescope effect;
+  avs::core::ParamBlock params;
+  params.setInt("color", 0x40FF80);
+  params.setString("blend_mode", "alpha");
+  effect.setParams(params);
+
+  auto analysis = makeAnalysis();
+  std::vector<std::uint8_t> pixels(96u * 64u * 4u, 0u);
+  auto context = makeContext(96, 64, pixels, analysis);
+
+  for (int i = 0; i < context.width; ++i) {
+    ASSERT_TRUE(effect.render(context));
+  }
+
+  const std::string hash = hashFNV1a(pixels);
+  EXPECT_EQ(hash, "7f5cc205");
+}
+
+TEST(RenderTimescopeTest, AdditiveBlendAccumulatesEnergy) {
+  avs::effects::render::Timescope effect;
+  avs::core::ParamBlock params;
+  params.setInt("color", 0xFF3366);
+  params.setString("blend_mode", "add");
+  params.setInt("bands", 128);
+  effect.setParams(params);
+
+  auto analysis = makeAnalysis();
+  std::vector<std::uint8_t> pixels(80u * 48u * 4u, 0u);
+  auto context = makeContext(80, 48, pixels, analysis);
+
+  for (int i = 0; i < context.width / 2; ++i) {
+    ASSERT_TRUE(effect.render(context));
+  }
+
+  const std::string hash = hashFNV1a(pixels);
+  EXPECT_EQ(hash, "f3af3865");
+}


### PR DESCRIPTION
## Summary
- implement the Render / Timescope effect using the audio analyzer waveform data with configurable blend modes
- hook the new effect into the registry and build system
- add regression tests that cover alpha and additive rendering paths

## Testing
- `./build/tests/core_effects_tests --gtest_filter=RenderTimescopeTest.*`


------
https://chatgpt.com/codex/tasks/task_e_68f85966cbd4832cbd942ec6bc98d75c