### PR TITLE
feat: implement svp loader effect

### DIFF
--- a/docs/compat/manifest.yaml
+++ b/docs/compat/manifest.yaml
@@ -152,8 +152,9 @@ stubs:
     status: stub
     source: vis_avs/r_simple.cpp (R_SimpleSpectrum)
   - name: Render / SVP Loader
-    status: stub
+    status: partial
     source: vis_avs/r_svp.cpp (R_SVP)
+    notes: "Loads legacy SVP/UVS plug-ins when available, otherwise acts as a no-op."
   - name: Render / Timescope
     status: stub
     source: vis_avs/r_timescope.cpp (R_Timescope)

--- a/docs/effects/stubs/render_svp_loader.md
+++ b/docs/effects/stubs/render_svp_loader.md
@@ -1,3 +1,25 @@
 # Render / SVP Loader
 
-This is a stub for compatibility with legacy AVS presets. No functional rendering is implemented yet.
+The SVP Loader bridges legacy Sonique Visualization Plug-in (SVP/UVS) modules with the
+modern renderer.  When a preset specifies a library, the loader attempts to resolve the
+path, dynamically load the module and invoke its `Render` entry point each frame.  On
+platforms that do not support dynamic libraries, or when a plug-in cannot be found, the
+loader safely falls back to a no-op so the preset chain continues to run.
+
+## Parameters
+
+- `library` / `path` / `file`: Preferred name or path to the SVP/UVS module.  Relative
+  paths are resolved against the current working directory and `resources/svp`.
+
+## Behaviour
+
+- Audio waveform and spectrum data are converted to the byte-oriented buffers expected by
+  SVP plug-ins.
+- Plug-ins receive a 32-bit BGRA framebuffer matching the current render target.
+- Settings are loaded from and saved to `avs.ini` placed alongside the selected module, if
+  the plug-in exposes `OpenSettings`/`SaveSettings` callbacks.
+- When loading fails the effect behaves as a pass-through renderer.
+
+> **Note:** Official SVP/UVS modules were shipped as Windows DLLs renamed to `.svp` or
+> `.uvs`.  They can only be executed on platforms that support the corresponding binary
+> format.

--- a/libs/avs/effects/CMakeLists.txt
+++ b/libs/avs/effects/CMakeLists.txt
@@ -4,7 +4,6 @@ set(AVS_EFFECT_STUB_SOURCES
   ${CMAKE_SOURCE_DIR}/src/effects/stubs/effect_render_moving_particle.cpp
   ${CMAKE_SOURCE_DIR}/src/effects/stubs/effect_render_oscilloscope_star.cpp
   ${CMAKE_SOURCE_DIR}/src/effects/stubs/effect_render_avi.cpp
-  ${CMAKE_SOURCE_DIR}/src/effects/stubs/effect_render_svp_loader.cpp
   ${CMAKE_SOURCE_DIR}/src/effects/stubs/effect_render_timescope.cpp
   ${CMAKE_SOURCE_DIR}/src/effects/stubs/effect_trans_brightness.cpp
   ${CMAKE_SOURCE_DIR}/src/effects/stubs/effect_trans_color_clip.cpp
@@ -72,6 +71,7 @@ add_library(avs-effects-core
   ${CMAKE_SOURCE_DIR}/src/effects/trans/effect_blur.cpp
   ${CMAKE_SOURCE_DIR}/src/effects/render/effect_rotating_stars.cpp
   ${CMAKE_SOURCE_DIR}/src/effects/render/effect_simple_spectrum.cpp
+  ${CMAKE_SOURCE_DIR}/src/effects/render/effect_svp_loader.cpp
   ${CMAKE_SOURCE_DIR}/src/effects/render/effect_oscilloscope_star.cpp
   ${CMAKE_SOURCE_DIR}/src/effects/render/effect_dot_plane.cpp
   ${CMAKE_SOURCE_DIR}/src/effects/render/effect_dot_fountain.cpp

--- a/libs/avs/effects/src/RegisterEffects.cpp
+++ b/libs/avs/effects/src/RegisterEffects.cpp
@@ -46,7 +46,7 @@
 #include "effects/render/effect_rotating_stars.h"
 #include "effects/render/effect_ring.h"
 #include "effects/render/effect_simple_spectrum.h"
-#include "effects/stubs/effect_render_svp_loader.h"
+#include "effects/render/effect_svp_loader.h"
 #include "effects/stubs/effect_render_timescope.h"
 #include "effects/trans/effect_color_clip.h"
 #include "effects/trans/effect_brightness.h"
@@ -141,8 +141,8 @@ void registerCoreEffects(avs::core::EffectRegistry& registry) {
   registry.registerFactory("render / rotating stars", []() { return std::make_unique<render::RotatingStars>(); });
   registry.registerFactory("Render / Simple", []() { return std::make_unique<render::SimpleSpectrum>(); });
   registry.registerFactory("render / simple", []() { return std::make_unique<render::SimpleSpectrum>(); });
-  registry.registerFactory("Render / SVP Loader", []() { return std::make_unique<Effect_RenderSvpLoader>(); });
-  registry.registerFactory("render / svp loader", []() { return std::make_unique<Effect_RenderSvpLoader>(); });
+  registry.registerFactory("Render / SVP Loader", []() { return std::make_unique<render::SvpLoader>(); });
+  registry.registerFactory("render / svp loader", []() { return std::make_unique<render::SvpLoader>(); });
   registry.registerFactory("Render / Timescope", []() { return std::make_unique<Effect_RenderTimescope>(); });
   registry.registerFactory("render / timescope", []() { return std::make_unique<Effect_RenderTimescope>(); });
   registry.registerFactory("Trans / Blitter Feedback", []() { return std::make_unique<trans::BlitterFeedback>(); });

--- a/src/effects/render/effect_svp_loader.cpp
+++ b/src/effects/render/effect_svp_loader.cpp
@@ -1,0 +1,358 @@
+#include "effects/render/effect_svp_loader.h"
+
+#include <algorithm>
+#include <cmath>
+#include <filesystem>
+#include <system_error>
+#include <vector>
+
+#include "audio/analyzer.h"
+
+#if defined(_WIN32)
+#include <windows.h>
+#else
+#  if defined(__has_include)
+#    if __has_include(<dlfcn.h>)
+#      define AVS_SVP_HAVE_DLOPEN 1
+#    endif
+#  endif
+#  ifndef AVS_SVP_HAVE_DLOPEN
+#    if defined(__unix__) || defined(__APPLE__)
+#      define AVS_SVP_HAVE_DLOPEN 1
+#    else
+#      define AVS_SVP_HAVE_DLOPEN 0
+#    endif
+#  endif
+#  if AVS_SVP_HAVE_DLOPEN
+#    include <dlfcn.h>
+#  endif
+#endif
+
+namespace avs::effects::render {
+namespace {
+
+#if defined(_WIN32)
+void* openLibrary(const std::string& path) {
+  std::filesystem::path fsPath(path);
+  std::wstring wide = fsPath.wstring();
+  HMODULE module = ::LoadLibraryW(wide.c_str());
+  return reinterpret_cast<void*>(module);
+}
+
+void closeLibrary(void* handle) {
+  if (handle) {
+    ::FreeLibrary(reinterpret_cast<HMODULE>(handle));
+  }
+}
+
+void* resolveSymbol(void* handle, const char* name) {
+  if (!handle) {
+    return nullptr;
+  }
+  return reinterpret_cast<void*>(
+      ::GetProcAddress(reinterpret_cast<HMODULE>(handle), name));
+}
+#else
+
+void* openLibrary(const std::string& path) {
+#if AVS_SVP_HAVE_DLOPEN
+  return ::dlopen(path.c_str(), RTLD_LAZY | RTLD_LOCAL);
+#else
+  (void)path;
+  return nullptr;
+#endif
+}
+
+void closeLibrary(void* handle) {
+#if AVS_SVP_HAVE_DLOPEN
+  if (handle) {
+    ::dlclose(handle);
+  }
+#else
+  (void)handle;
+#endif
+}
+
+void* resolveSymbol(void* handle, const char* name) {
+#if AVS_SVP_HAVE_DLOPEN
+  if (!handle) {
+    return nullptr;
+  }
+  return ::dlsym(handle, name);
+#else
+  (void)handle;
+  (void)name;
+  return nullptr;
+#endif
+}
+
+#endif  // defined(_WIN32)
+
+std::uint8_t clampToByte(float value) {
+  value = std::clamp(value, 0.0f, 255.0f);
+  return static_cast<std::uint8_t>(std::lround(value));
+}
+
+}  // namespace
+
+SvpLoader::SvpLoader() = default;
+
+SvpLoader::~SvpLoader() {
+  std::lock_guard<std::mutex> lock(mutex_);
+  unloadLibraryLocked();
+}
+
+void SvpLoader::setParams(const avs::core::ParamBlock& params) {
+  std::string requested = params.getString("library");
+  if (requested.empty()) {
+    requested = params.getString("path");
+  }
+  if (requested.empty()) {
+    requested = params.getString("file");
+  }
+
+  std::lock_guard<std::mutex> lock(mutex_);
+  if (requested != requestedLibrary_) {
+    requestedLibrary_ = requested;
+    libraryDirty_ = true;
+  } else if (!requested.empty() && !libraryHandle_) {
+    libraryDirty_ = true;
+  }
+}
+
+bool SvpLoader::render(avs::core::RenderContext& context) {
+  std::lock_guard<std::mutex> lock(mutex_);
+  reloadLibraryLocked();
+
+  if (!visInfo_ || !visInfo_->render) {
+    return true;
+  }
+  if (!hasFramebuffer(context)) {
+    return true;
+  }
+
+  LegacyVisData data{};
+  populateVisData(context, data);
+
+  auto* pixels = reinterpret_cast<std::uint32_t*>(context.framebuffer.data);
+  const int pitch = context.width;
+  const int result = visInfo_->render(pixels, context.width, context.height, pitch, &data);
+  (void)result;
+  return true;
+}
+
+void SvpLoader::reloadLibraryLocked() {
+  if (!libraryDirty_) {
+    return;
+  }
+  libraryDirty_ = false;
+
+  unloadLibraryLocked();
+  if (requestedLibrary_.empty()) {
+    return;
+  }
+
+  const std::string resolved = resolveLibraryPath(requestedLibrary_);
+  if (resolved.empty()) {
+    return;
+  }
+
+  void* handle = openLibrary(resolved);
+  if (!handle) {
+    return;
+  }
+
+  void* symbol = resolveSymbol(handle, "QueryModule");
+  if (!symbol) {
+    symbol = resolveSymbol(handle, "?QueryModule@@YAPAUUltraVisInfo@@XZ");
+  }
+  if (!symbol) {
+    closeLibrary(handle);
+    return;
+  }
+
+  queryModule_ = reinterpret_cast<QueryModuleFn>(symbol);
+  LegacyVisInfo* info = queryModule_ ? queryModule_() : nullptr;
+  if (!info || !info->render) {
+    queryModule_ = nullptr;
+    closeLibrary(handle);
+    return;
+  }
+
+  libraryHandle_ = handle;
+  visInfo_ = info;
+  loadedLibraryPath_ = resolved;
+  updateConfigBuffer(resolved);
+
+  if (visInfo_->openSettings && !configFileBuffer_.empty()) {
+    visInfo_->openSettings(configFileBuffer_.data());
+  }
+  if (visInfo_->initialize) {
+    visInfo_->initialize();
+  }
+  startTimeInitialized_ = false;
+}
+
+void SvpLoader::unloadLibraryLocked() {
+  if (visInfo_ && visInfo_->saveSettings && !configFileBuffer_.empty()) {
+    visInfo_->saveSettings(configFileBuffer_.data());
+  }
+  if (libraryHandle_) {
+    closeLibrary(libraryHandle_);
+  }
+  libraryHandle_ = nullptr;
+  visInfo_ = nullptr;
+  queryModule_ = nullptr;
+  loadedLibraryPath_.clear();
+  configFileBuffer_.clear();
+}
+
+std::string SvpLoader::resolveLibraryPath(const std::string& candidate) const {
+  namespace fs = std::filesystem;
+  if (candidate.empty()) {
+    return {};
+  }
+
+  auto addAttempt = [](const fs::path& base, std::vector<fs::path>& attempts) {
+    if (base.empty()) {
+      return;
+    }
+    attempts.push_back(base);
+    if (base.extension().empty()) {
+      attempts.push_back(base.string() + ".svp");
+      attempts.push_back(base.string() + ".uvs");
+      attempts.push_back(base.string() + ".dll");
+    }
+  };
+
+  std::vector<fs::path> attempts;
+  fs::path raw(candidate);
+  std::error_code ec;
+  const fs::path cwd = fs::current_path(ec);
+
+  if (raw.is_absolute()) {
+    addAttempt(raw, attempts);
+  } else {
+    if (!cwd.empty()) {
+      addAttempt(cwd / raw, attempts);
+      addAttempt(cwd / "resources" / "svp" / raw, attempts);
+      addAttempt(cwd / "resources" / "plugins" / raw, attempts);
+    }
+    addAttempt(raw, attempts);
+  }
+
+  for (const fs::path& attempt : attempts) {
+    if (attempt.empty()) {
+      continue;
+    }
+    std::error_code existsEc;
+    if (fs::exists(attempt, existsEc) && !fs::is_directory(attempt, existsEc)) {
+      std::error_code absoluteEc;
+      fs::path absolute = fs::absolute(attempt, absoluteEc);
+      if (absolute.empty() || absoluteEc) {
+        return attempt.string();
+      }
+      return absolute.string();
+    }
+  }
+
+  return {};
+}
+
+void SvpLoader::updateConfigBuffer(const std::string& libraryPath) {
+  configFileBuffer_.clear();
+  if (libraryPath.empty()) {
+    return;
+  }
+  std::filesystem::path path(libraryPath);
+  std::filesystem::path ini = path.parent_path() / "avs.ini";
+  const std::string iniString = ini.string();
+  configFileBuffer_.assign(iniString.begin(), iniString.end());
+  configFileBuffer_.push_back('\0');
+}
+
+void SvpLoader::populateVisData(const avs::core::RenderContext& context, LegacyVisData& data) {
+  for (auto& channel : data.waveform) {
+    channel.fill(128);
+  }
+  for (auto& channel : data.spectrum) {
+    channel.fill(0);
+  }
+
+  const auto now = std::chrono::steady_clock::now();
+  if (!startTimeInitialized_) {
+    startTime_ = now;
+    startTimeInitialized_ = true;
+  }
+  data.millisecond = static_cast<std::uint32_t>(
+      std::chrono::duration_cast<std::chrono::milliseconds>(now - startTime_).count());
+
+  const avs::audio::Analysis* analysis = context.audioAnalysis;
+  if (analysis) {
+    const auto& waveform = analysis->waveform;
+    const std::size_t copyCount = std::min<std::size_t>(waveform.size(), data.waveform[0].size());
+    for (std::size_t i = 0; i < copyCount; ++i) {
+      const std::uint8_t sample = convertWaveformSample(waveform[i]);
+      data.waveform[0][i] = sample;
+      data.waveform[1][i] = sample;
+    }
+  }
+
+  const float* spectrumData = nullptr;
+  std::size_t spectrumSize = 0;
+  if (context.audioSpectrum.data && context.audioSpectrum.size > 0) {
+    spectrumData = context.audioSpectrum.data;
+    spectrumSize = context.audioSpectrum.size;
+  } else if (analysis) {
+    spectrumData = analysis->spectrum.data();
+    spectrumSize = analysis->spectrum.size();
+  }
+
+  const std::size_t maxBins = data.spectrum[0].size();
+  for (std::size_t i = 0; i < maxBins; ++i) {
+    const std::size_t idx = i * 2;
+    float value = 0.0f;
+    if (spectrumData && idx < spectrumSize) {
+      value = spectrumData[idx];
+      if (idx + 1 < spectrumSize) {
+        value = (value + spectrumData[idx + 1]) * 0.5f;
+      }
+    }
+    const std::uint8_t sample = convertSpectrumSample(value);
+    data.spectrum[0][i] = sample;
+    data.spectrum[1][i] = sample;
+  }
+}
+
+std::uint8_t SvpLoader::convertWaveformSample(float value) {
+  if (!std::isfinite(value)) {
+    value = 0.0f;
+  }
+  value = std::clamp(value, -1.0f, 1.0f);
+  const float scaled = (value + 1.0f) * 127.5f;
+  return clampToByte(scaled);
+}
+
+std::uint8_t SvpLoader::convertSpectrumSample(float value) {
+  if (!std::isfinite(value)) {
+    value = 0.0f;
+  }
+  value = std::max(0.0f, value);
+  const float scaled = value * 4.0f;
+  return clampToByte(scaled);
+}
+
+bool SvpLoader::hasFramebuffer(const avs::core::RenderContext& context) {
+  if (context.width <= 0 || context.height <= 0) {
+    return false;
+  }
+  if (!context.framebuffer.data) {
+    return false;
+  }
+  const std::size_t required = static_cast<std::size_t>(context.width) *
+                               static_cast<std::size_t>(context.height) * 4u;
+  return context.framebuffer.size >= required;
+}
+
+}  // namespace avs::effects::render
+

--- a/src/effects/render/effect_svp_loader.h
+++ b/src/effects/render/effect_svp_loader.h
@@ -1,0 +1,78 @@
+#pragma once
+
+#include <array>
+#include <chrono>
+#include <cstdint>
+#include <mutex>
+#include <string>
+#include <vector>
+
+#include "avs/core/IEffect.hpp"
+
+namespace avs::effects::render {
+
+/**
+ * @brief Loads legacy Sonique Visualization Plug-in (SVP/UVS) modules.
+ *
+ * The loader mirrors the behaviour of the original Winamp AVS "Render / SVP Loader"
+ * component.  When a plug-in library is available it is dynamically loaded and used to
+ * render into the current framebuffer.  On platforms without dynamic library support, or
+ * when the requested plug-in cannot be found, the effect gracefully degrades to a no-op so
+ * presets can continue executing.
+ */
+class SvpLoader : public avs::core::IEffect {
+ public:
+  SvpLoader();
+  ~SvpLoader() override;
+
+  void setParams(const avs::core::ParamBlock& params) override;
+  bool render(avs::core::RenderContext& context) override;
+
+ private:
+  struct LegacyVisData {
+    std::uint32_t millisecond = 0;
+    std::array<std::array<std::uint8_t, 512>, 2> waveform{};
+    std::array<std::array<std::uint8_t, 256>, 2> spectrum{};
+  };
+
+  struct LegacyVisInfo {
+    using LegacyBool = int;
+    using InitializeFn = void (*)();
+    using RenderFn = LegacyBool (*)(std::uint32_t*, int, int, int, LegacyVisData*);
+    using SettingsFn = LegacyBool (*)(char*);
+
+    std::uint32_t reserved = 0;
+    const char* pluginName = nullptr;
+    std::int32_t requiredFlags = 0;
+    InitializeFn initialize = nullptr;
+    RenderFn render = nullptr;
+    SettingsFn saveSettings = nullptr;
+    SettingsFn openSettings = nullptr;
+  };
+
+  using QueryModuleFn = LegacyVisInfo* (*)();
+  using LibraryHandle = void*;
+
+  void reloadLibraryLocked();
+  void unloadLibraryLocked();
+  std::string resolveLibraryPath(const std::string& candidate) const;
+  void updateConfigBuffer(const std::string& libraryPath);
+  void populateVisData(const avs::core::RenderContext& context, LegacyVisData& data);
+  static std::uint8_t convertWaveformSample(float value);
+  static std::uint8_t convertSpectrumSample(float value);
+  static bool hasFramebuffer(const avs::core::RenderContext& context);
+
+  std::mutex mutex_;
+  std::string requestedLibrary_;
+  std::string loadedLibraryPath_;
+  std::vector<char> configFileBuffer_;
+  LibraryHandle libraryHandle_ = nullptr;
+  LegacyVisInfo* visInfo_ = nullptr;
+  QueryModuleFn queryModule_ = nullptr;
+  bool libraryDirty_ = false;
+  bool startTimeInitialized_ = false;
+  std::chrono::steady_clock::time_point startTime_{};
+};
+
+}  // namespace avs::effects::render
+

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -72,6 +72,7 @@ add_executable(core_effects_tests
   core/test_render_dot_fountain.cpp
   core/test_render_bass_spin.cpp
   core/test_render_moving_particle.cpp
+  core/test_render_svp_loader.cpp
   core/test_render_mode.cpp
   core/test_misc_comment.cpp
   core/test_trans_multiplier.cpp

--- a/tests/core/test_render_svp_loader.cpp
+++ b/tests/core/test_render_svp_loader.cpp
@@ -1,0 +1,63 @@
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "audio/analyzer.h"
+#include "avs/core/ParamBlock.hpp"
+#include "avs/core/RenderContext.hpp"
+#include "effects/render/effect_svp_loader.h"
+
+namespace {
+
+constexpr int kWidth = 32;
+constexpr int kHeight = 24;
+
+avs::core::RenderContext makeContext(std::vector<std::uint8_t>& pixels,
+                                     avs::audio::Analysis& analysis) {
+  avs::core::RenderContext ctx{};
+  ctx.width = kWidth;
+  ctx.height = kHeight;
+  ctx.framebuffer = {pixels.data(), pixels.size()};
+  ctx.audioAnalysis = &analysis;
+  ctx.audioSpectrum = {analysis.spectrum.data(), analysis.spectrum.size()};
+  return ctx;
+}
+
+}  // namespace
+
+TEST(SvpLoaderEffectTest, DoesNothingWhenNoLibraryIsConfigured) {
+  avs::effects::render::SvpLoader effect;
+  std::vector<std::uint8_t> pixels(
+      static_cast<std::size_t>(kWidth) * static_cast<std::size_t>(kHeight) * 4u, 42u);
+  avs::audio::Analysis analysis{};
+  auto context = makeContext(pixels, analysis);
+
+  EXPECT_TRUE(effect.render(context));
+
+  for (std::uint8_t value : pixels) {
+    EXPECT_EQ(value, 42u);
+  }
+}
+
+TEST(SvpLoaderEffectTest, HandlesMissingLibraryGracefully) {
+  avs::effects::render::SvpLoader effect;
+  avs::core::ParamBlock params;
+  params.setString("library", "definitely_missing_plugin.svp");
+  effect.setParams(params);
+
+  std::vector<std::uint8_t> pixels(
+      static_cast<std::size_t>(kWidth) * static_cast<std::size_t>(kHeight) * 4u, 17u);
+  avs::audio::Analysis analysis{};
+  analysis.spectrum.fill(0.0f);
+  analysis.waveform.fill(0.0f);
+  auto context = makeContext(pixels, analysis);
+
+  EXPECT_TRUE(effect.render(context));
+
+  for (std::uint8_t value : pixels) {
+    EXPECT_EQ(value, 17u);
+  }
+}
+


### PR DESCRIPTION
## Summary
- add a render::SvpLoader effect that dynamically loads legacy SVP/UVS modules with a safe fallback path
- wire the loader into the core registry/build and refresh the SVP documentation entry
- cover the no-library and missing-library flows with unit tests

## Testing
- cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug *(fails: PortAudio not found)*

------
https://chatgpt.com/codex/tasks/task_e_68f86129e380832c9f946f6d6efdad9e