### PR TITLE
Fix Timescope channel selection warning on GCC

### DIFF
--- a/src/effects/render/effect_timescope.cpp
+++ b/src/effects/render/effect_timescope.cpp
@@ -152,6 +152,7 @@ void Timescope::applyParams(const avs::core::ParamBlock& params) {
   bandCount_ = std::clamp(params.getInt("nbands", bandCount_), kMinBands, kMaxBands);
   if (params.contains("which_ch")) {
     channelSelection_ = params.getInt("which_ch", channelSelection_);
+    channelSelection_ = std::clamp(channelSelection_, 0, 2);
   }
 
   ensureBandCapacity();

--- a/src/effects/render/effect_timescope.h
+++ b/src/effects/render/effect_timescope.h
@@ -49,7 +49,7 @@ class Timescope : public avs::core::IEffect {
   Color color_{};
   BlendMode blendMode_ = BlendMode::Line;
   bool blendAverage_ = false;
-  [[maybe_unused]] int channelSelection_ = 2;
+  int channelSelection_ = 2;
   int bandCount_ = 576;
   int cursor_ = -1;
   float normalization_ = 1.0f;


### PR DESCRIPTION
## Summary
- remove the unused attribute from Timescope's channel selection field
- clamp the stored channel selection parameter to the supported range when applying params

## Testing
- `cmake --build build --config Release`
- `ctest --output-on-failure` *(fails: core_effects_tests / MultiDelayEffectTest.ResetsWhenFrameSizeChanges)*

------
https://chatgpt.com/codex/tasks/task_e_68f871b69804832c9a474295a3ae80a1